### PR TITLE
fix(account-management): ensure public keys are retrieved correctly

### DIFF
--- a/components/screens/full-pages/account-management/ManageAccounts.tsx
+++ b/components/screens/full-pages/account-management/ManageAccounts.tsx
@@ -70,9 +70,18 @@ export default function ManageAccounts({ listAccounts }: ManageAccountsProps) {
       // Fill the publicKeys to the accounts object, or the accounts would be missing the public keys
       const accounts = Object.entries(data).reduce((acc, [index, value]) => {
         if (value.active) {
+          const accountIndex = parseInt(index, 10);
+          const publicKeys =
+            accountList[accountIndex]?.publicKeys ||
+            selectedAccountIds?.[index]?.publicKeys;
+
+          if (!publicKeys) {
+            throw new Error("Public keys not found");
+          }
+
           acc[index] = {
             active: value.active,
-            publicKeys: accountList[parseInt(index)].publicKeys,
+            publicKeys,
           };
         }
         return acc;


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [x] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

Fix the error that occurs when the selected account is not included in the account management list on the manage page. For example, if "Account 10" is selected but not displayed on the page, an error occurs:

![image](https://github.com/user-attachments/assets/63ff32c8-483f-4ca7-97e5-96c5ebdd22e4)
![image](https://github.com/user-attachments/assets/d1c6bed4-213f-44f2-aa82-fbb5ba0a4c7f)


---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [x] My contribution is made under the [Business Source License](LICENSE)
- [x] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [x] I have the authority to make this contribution and license it appropriately
