### PR TITLE
fix(auto-lock): keep auto lock manager alive in background

### DIFF
--- a/lib/auto-lock-manager.ts
+++ b/lib/auto-lock-manager.ts
@@ -3,6 +3,7 @@ import { ExtensionService } from "@/lib/service/extension-service.ts";
 import { storage } from "wxt/storage";
 
 export const AUTO_LOCK_ALARM = "auto-lock-alarm";
+export const KEEP_ALIVE_ALARM = "keep-alive";
 export const DEFAULT_AUTO_LOCK_MINUTES = 5;
 
 export class AutoLockManager {
@@ -24,6 +25,9 @@ export class AutoLockManager {
         });
       }
     });
+
+    // start an alarm to keep the extension alive
+    browser.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 });
 
     browser.alarms.onAlarm.addListener(async (alarm) => {
       if (alarm.name === AUTO_LOCK_ALARM) {


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

This PR aims to fix the issue of the wallet being locked too early due to the browser turning off the service worker when no operations occur for a while in the background.

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately
