### PR TITLE
fix: ensure service worker stays alive until auto-lock completes

### DIFF
--- a/lib/auto-lock-manager.ts
+++ b/lib/auto-lock-manager.ts
@@ -3,6 +3,7 @@ import { ExtensionService } from "@/lib/service/extension-service.ts";
 import { storage } from "wxt/storage";
 
 export const AUTO_LOCK_ALARM = "auto-lock-alarm";
+export const KEEP_ALIVE_ALARM = "keep-alive";
 export const DEFAULT_AUTO_LOCK_MINUTES = 5;
 
 export class AutoLockManager {
@@ -24,6 +25,9 @@ export class AutoLockManager {
         });
       }
     });
+
+    // start an alarm to keep the extension alive
+    browser.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 });
 
     browser.alarms.onAlarm.addListener(async (alarm) => {
       if (alarm.name === AUTO_LOCK_ALARM) {

--- a/lib/auto-lock-manager.ts
+++ b/lib/auto-lock-manager.ts
@@ -4,7 +4,7 @@ import { storage } from "wxt/storage";
 
 export const AUTO_LOCK_ALARM = "auto-lock-alarm";
 export const DEFAULT_AUTO_LOCK_MINUTES = 5;
-const MAX_AUTO_LOCK_MINUTES = 30;
+const MAX_AUTO_LOCK_MINUTES = 60;
 const KEEP_ALIVE_INTERVAL = 25 * 1000;
 const KEEP_ALIVE_KEY = "local:keep-alive";
 
@@ -25,7 +25,7 @@ export class AutoLockManager {
         this.clearInactivityAlarm();
 
         port.onDisconnect.addListener(() => {
-          // Keep alive until the keyring is locked (max 30 minutes)
+          // Keep alive until the keyring is locked (max 60 minutes)
           this.startKeepAlive();
           this.resetInactivityAlarm();
         });
@@ -43,7 +43,7 @@ export class AutoLockManager {
 
     storage.watch(SETTINGS_KEY, async () => {
       let timeout = await this.getLockTimeout();
-      // Limit the maximum auto lock time to 30 minutes
+      // Limit the maximum auto lock time to 60 minutes
       if (timeout > MAX_AUTO_LOCK_MINUTES) timeout = MAX_AUTO_LOCK_MINUTES;
 
       if (this.timeout !== timeout) {

--- a/lib/auto-lock-manager.ts
+++ b/lib/auto-lock-manager.ts
@@ -3,10 +3,14 @@ import { ExtensionService } from "@/lib/service/extension-service.ts";
 import { storage } from "wxt/storage";
 
 export const AUTO_LOCK_ALARM = "auto-lock-alarm";
-export const KEEP_ALIVE_ALARM = "keep-alive";
 export const DEFAULT_AUTO_LOCK_MINUTES = 5;
+const MAX_AUTO_LOCK_MINUTES = 30;
+const KEEP_ALIVE_INTERVAL = 25 * 1000;
+const KEEP_ALIVE_KEY = "local:keep-alive";
 
 export class AutoLockManager {
+  keepAlive: NodeJS.Timeout | undefined;
+
   constructor(private timeout: number = DEFAULT_AUTO_LOCK_MINUTES) {
     // Load settings from storage if settings are not loaded yet
     this.getLockTimeout().then((timeout) => {
@@ -21,26 +25,45 @@ export class AutoLockManager {
         this.clearInactivityAlarm();
 
         port.onDisconnect.addListener(() => {
+          // Keep alive until the keyring is locked (max 30 minutes)
+          this.startKeepAlive();
           this.resetInactivityAlarm();
         });
       }
     });
 
-    // start an alarm to keep the extension alive
-    browser.alarms.create(KEEP_ALIVE_ALARM, { periodInMinutes: 1 });
-
     browser.alarms.onAlarm.addListener(async (alarm) => {
       if (alarm.name === AUTO_LOCK_ALARM) {
         await this.executeAutoLock();
+
+        // Stop keep alive after the keyring is locked
+        this.stopKeepAlive();
       }
     });
 
     storage.watch(SETTINGS_KEY, async () => {
-      const timeout = await this.getLockTimeout();
+      let timeout = await this.getLockTimeout();
+      // Limit the maximum auto lock time to 30 minutes
+      if (timeout > MAX_AUTO_LOCK_MINUTES) timeout = MAX_AUTO_LOCK_MINUTES;
+
       if (this.timeout !== timeout) {
         this.timeout = timeout;
       }
     });
+  }
+
+  private startKeepAlive() {
+    if (this.keepAlive) clearInterval(this.keepAlive);
+
+    this.keepAlive = setInterval(() => {
+      chrome.runtime.getPlatformInfo();
+      storage.setItem(KEEP_ALIVE_KEY, Date.now());
+    }, KEEP_ALIVE_INTERVAL);
+  }
+
+  private stopKeepAlive() {
+    if (this.keepAlive) clearInterval(this.keepAlive);
+    this.keepAlive = undefined;
   }
 
   private async getLockTimeout() {

--- a/lib/auto-lock-manager.ts
+++ b/lib/auto-lock-manager.ts
@@ -20,9 +20,9 @@ export class AutoLockManager {
 
   listen() {
     // start listeners
-    browser.runtime.onConnect.addListener((port) => {
+    browser.runtime.onConnect.addListener(async (port) => {
       if (port.name === "popup") {
-        this.clearInactivityAlarm();
+        await this.clearInactivityAlarm();
 
         port.onDisconnect.addListener(() => {
           // Keep alive until the keyring is locked (max 60 minutes)
@@ -55,9 +55,9 @@ export class AutoLockManager {
   private startKeepAlive() {
     if (this.keepAlive) clearInterval(this.keepAlive);
 
-    this.keepAlive = setInterval(() => {
-      chrome.runtime.getPlatformInfo();
-      storage.setItem(KEEP_ALIVE_KEY, Date.now());
+    this.keepAlive = setInterval(async () => {
+      await chrome.runtime.getPlatformInfo();
+      await storage.setItem(KEEP_ALIVE_KEY, Date.now());
     }, KEEP_ALIVE_INTERVAL);
   }
 
@@ -79,13 +79,13 @@ export class AutoLockManager {
     });
   }
 
-  private clearInactivityAlarm() {
-    browser.alarms.clear(AUTO_LOCK_ALARM);
+  private async clearInactivityAlarm() {
+    await browser.alarms.clear(AUTO_LOCK_ALARM);
   }
 
-  private executeAutoLock() {
+  private async executeAutoLock() {
     const extensionService = ExtensionService.getInstance();
     extensionService.getKeyring().lock();
-    browser.alarms.clear(AUTO_LOCK_ALARM);
+    await browser.alarms.clear(AUTO_LOCK_ALARM);
   }
 }


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

This PR fixes auto-lock timer inconsistencies caused by Chrome deactivating the service worker.

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately
