### PR TITLE
feat(api): support object parameters for evm `wallet_watchAsset` api

### DIFF
--- a/api/background/handlers/ethereum/sendTransaction.ts
+++ b/api/background/handlers/ethereum/sendTransaction.ts
@@ -44,12 +44,12 @@ export const sendTransactionHandler = async (
   }
 
   const request = RpcRequestSchema.parse(message.payload);
-  const { params } = request;
-  if (!params || params.length < 1) {
+  if (!Array.isArray(request.params) || request.params.length < 1) {
     sendError(RPC_ERRORS.INVALID_PARAMS);
     return;
   }
 
+  const { params } = request;
   const payload = params[0];
   const result = ethereumTransactionRequestSchema.safeParse(payload);
   if (!result.success) {

--- a/api/background/handlers/ethereum/signMessage.ts
+++ b/api/background/handlers/ethereum/signMessage.ts
@@ -26,12 +26,12 @@ export const signMessageHandler = async (
   }
 
   const request = RpcRequestSchema.parse(message.payload);
-  const { params } = request;
-  if (!params || params.length < 2) {
+  if (!Array.isArray(request.params) || request.params.length < 2) {
     sendError(RPC_ERRORS.INVALID_PARAMS);
     return;
   }
 
+  const { params } = request;
   const fromAddress = params[1];
   const addressResult = z
     .string()

--- a/api/background/handlers/ethereum/signTypedDataV4.ts
+++ b/api/background/handlers/ethereum/signTypedDataV4.ts
@@ -25,12 +25,12 @@ export const signTypedDataV4Handler = async (
   }
 
   const request = RpcRequestSchema.parse(message.payload);
-  const { params } = request;
-  if (!params || params.length < 2) {
+  if (!Array.isArray(request.params) || request.params.length < 2) {
     sendError(RPC_ERRORS.INVALID_PARAMS);
     return;
   }
 
+  const { params } = request;
   const fromAddress = params[0];
   const addressResult = z
     .string()

--- a/api/background/handlers/ethereum/switchNetwork.ts
+++ b/api/background/handlers/ethereum/switchNetwork.ts
@@ -18,7 +18,7 @@ export const switchNetworkHandler = async (
   sendResponse: (response?: any) => void,
 ) => {
   const request = RpcRequestSchema.parse(message.payload);
-  if (!request.params || request.params.length < 1) {
+  if (!Array.isArray(request.params) || request.params.length < 1) {
     sendResponse(
       ApiUtils.createApiResponse(message.id, null, RPC_ERRORS.INVALID_PARAMS),
     );

--- a/api/ethereum.ts
+++ b/api/ethereum.ts
@@ -28,9 +28,6 @@ export class EthereumBrowserAPI {
   >();
 
   request(request: RpcRequest) {
-    console.log(
-      `EthereumBrowserAPI.request: ${request.method} with params: ${JSON.stringify(request.params)}`,
-    );
     const requestId = uuid();
     const apiRequest = createApiRequest(
       Action.ETHEREUM_REQUEST,

--- a/api/ethereum.ts
+++ b/api/ethereum.ts
@@ -28,6 +28,9 @@ export class EthereumBrowserAPI {
   >();
 
   request(request: RpcRequest) {
+    console.log(
+      `EthereumBrowserAPI.request: ${request.method} with params: ${JSON.stringify(request.params)}`,
+    );
     const requestId = uuid();
     const apiRequest = createApiRequest(
       Action.ETHEREUM_REQUEST,

--- a/api/message.ts
+++ b/api/message.ts
@@ -15,7 +15,7 @@ export enum Action {
 
 export const RpcRequestSchema = z.object({
   method: z.string(),
-  params: z.array(z.unknown()).optional(),
+  params: z.array(z.unknown()).or(z.unknown()).optional(),
 });
 
 export type RpcRequest = z.infer<typeof RpcRequestSchema>;


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

This PR supports object parameter to make object allowed to be a parameter like:
```js
kastle.ethereum.request({
    method: "ERC20",
    options: {"type":"ERC20","options":{"address":"0xEcff9AabD043e49C450A73808c7a16Aa96e2000F","decimals":18,"symbol":"USDT"}}
})
```

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately
