### PR TITLE
fix(api): ensure sending user denied message when close the popup window

### DIFF
--- a/api/background/handlers/ethereum/sendTransaction.ts
+++ b/api/background/handlers/ethereum/sendTransaction.ts
@@ -73,10 +73,12 @@ export const sendTransactionHandler = async (
     encodeURIComponent(JSON.stringify(transaction)),
   );
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  // Wait for the response from the popup
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   if (isUserDeniedResponse(response)) {
     sendResponse(
       ApiUtils.createApiResponse(

--- a/api/background/handlers/ethereum/signMessage.ts
+++ b/api/background/handlers/ethereum/signMessage.ts
@@ -63,10 +63,12 @@ export const signMessageHandler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("payload", encodeURIComponent(parsedPayload));
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  // Wait for the response from the popup
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   if (isUserDeniedResponse(response)) {
     sendResponse(
       ApiUtils.createApiResponse(

--- a/api/background/handlers/ethereum/signTypedDataV4.ts
+++ b/api/background/handlers/ethereum/signTypedDataV4.ts
@@ -63,10 +63,12 @@ export const signTypedDataV4Handler = async (
     encodeURIComponent(JSON.stringify(transaction)),
   );
 
-  await ApiUtils.openPopup(tabId, url.toString());
-
-  // Wait for the response from the popup
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   if (isUserDeniedResponse(response)) {
     sendResponse(
       ApiUtils.createApiResponse(

--- a/api/background/handlers/ethereum/switchNetwork.ts
+++ b/api/background/handlers/ethereum/switchNetwork.ts
@@ -46,7 +46,11 @@ export const switchNetworkHandler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("network", network.toString());
 
-  ApiUtils.openPopup(tabId, url.toString());
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/handlers/ethereum/utils.ts
+++ b/api/background/handlers/ethereum/utils.ts
@@ -16,7 +16,7 @@ export const isMatchCurrentAddress = async (address: string) => {
 
 export const isUserDeniedResponse = (response: unknown) => {
   const result = ApiResponseSchema.safeParse(response);
-  return result.success && result.data.error === "User Denied";
+  return result.success && result.data.error === "User denied";
 };
 
 export const TESTNET_SUPPORTED_EVM_L2_CHAINS = [

--- a/api/background/handlers/ethereum/watchAsset.ts
+++ b/api/background/handlers/ethereum/watchAsset.ts
@@ -107,10 +107,12 @@ export const watchAssetHandler = async (
     encodeURIComponent(JSON.stringify(parsedPayload)),
   );
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  // Wait for the response from the popup
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   if (isUserDeniedResponse(response)) {
     sendResponse(
       ApiUtils.createApiResponse(

--- a/api/background/handlers/kaspa/connect.ts
+++ b/api/background/handlers/kaspa/connect.ts
@@ -52,8 +52,11 @@ export const connectHandler: Handler = async (
   url.searchParams.set("name", parsedPayload.name);
   url.searchParams.set("icon", parsedPayload.icon ?? "");
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/handlers/kaspa/getAccount.ts
+++ b/api/background/handlers/kaspa/getAccount.ts
@@ -1,5 +1,5 @@
 import { ApiUtils, Handler } from "@/api/background/utils";
-import { ApiRequest, ApiRequestWithHost } from "@/api/message";
+import { ApiRequestWithHost } from "@/api/message";
 
 /** getAccount handler to serve BrowserMessageType.GET_ADDRESS message */
 export const getAccountHandler: Handler = async (

--- a/api/background/handlers/kaspa/signAndBroadcastTx.ts
+++ b/api/background/handlers/kaspa/signAndBroadcastTx.ts
@@ -49,8 +49,11 @@ export const signAndBroadcastTxHandler: Handler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("payload", JSON.stringify(result.data));
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/handlers/kaspa/signMessage.ts
+++ b/api/background/handlers/kaspa/signMessage.ts
@@ -57,8 +57,11 @@ export const signMessageHandler: Handler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("payload", JSON.stringify(result.data));
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/handlers/kaspa/signTx.ts
+++ b/api/background/handlers/kaspa/signTx.ts
@@ -42,8 +42,11 @@ export const signTxHandler: Handler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("payload", JSON.stringify(result.data));
 
-  ApiUtils.openPopup(tabId, url.toString());
-
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/handlers/kaspa/switchNetwork.ts
+++ b/api/background/handlers/kaspa/switchNetwork.ts
@@ -40,7 +40,11 @@ export const switchNetworkHandler = async (
   url.searchParams.set("requestId", message.id);
   url.searchParams.set("network", network);
 
-  ApiUtils.openPopup(tabId, url.toString());
-  const response = await ApiUtils.receiveExtensionMessage(message.id);
+  // Open the popup and wait for the response
+  const response = await ApiUtils.openPopupAndListenForResponse(
+    message.id,
+    url.toString(),
+    tabId,
+  );
   sendResponse(response);
 };

--- a/api/background/utils.ts
+++ b/api/background/utils.ts
@@ -20,7 +20,7 @@ import { kasplexTestnet } from "@/lib/layer2";
 
 export class ApiUtils {
   static openPopup(tabId: number, url: string) {
-    browser.windows.create({
+    return browser.windows.create({
       tabId,
       type: "popup",
       url,
@@ -128,19 +128,35 @@ export class ApiUtils {
     });
   }
 
-  static async receiveExtensionMessage(
-    id: string,
+  static async openPopupAndListenForResponse(
+    requestId: string,
+    url: string,
+    tabId: number,
     timeout = 60_000, // 1 minute
-  ): Promise<unknown> {
-    return new Promise<unknown>((resolve, reject) => {
-      const listener = (message: unknown) => {
+  ) {
+    const popup = await this.openPopup(tabId, url);
+    let onRemovedListener: ((windowId: number) => void) | null = null;
+    let receiveListener: ((message: unknown) => void) | null = null;
+    let receiveTimeout: NodeJS.Timeout | null = null;
+
+    const onClosePromise = new Promise((resolve, _) => {
+      onRemovedListener = (windowId: number) => {
+        if (windowId === popup.id) {
+          resolve(this.createApiResponse(requestId, null, "User denied"));
+        }
+      };
+      browser.windows.onRemoved.addListener(onRemovedListener);
+    });
+
+    const onMessagePromise = new Promise((resolve, reject) => {
+      receiveListener = (message: unknown) => {
         const result = ApiExtensionResponseSchema.safeParse(message);
         if (!result.success) {
           return;
         }
 
         const parsedMessage = result.data;
-        if (parsedMessage.id !== id) {
+        if (parsedMessage.id !== requestId) {
           return;
         }
 
@@ -149,17 +165,28 @@ export class ApiUtils {
           return;
         }
 
-        browser.runtime.onMessage.removeListener(listener);
         resolve(parsedMessage.response);
       };
 
-      browser.runtime.onMessage.addListener(listener);
-
-      setTimeout(() => {
-        browser.runtime.onMessage.removeListener(listener);
+      receiveTimeout = setTimeout(() => {
         reject(RPC_ERRORS.TIMEOUT);
       }, timeout);
+
+      browser.runtime.onMessage.addListener(receiveListener);
     });
+
+    const result = await Promise.race([onClosePromise, onMessagePromise]);
+
+    // Ensure the listeners and timeout are cleaned up
+    if (onRemovedListener)
+      browser.windows.onRemoved.removeListener(onRemovedListener);
+
+    if (receiveListener)
+      browser.runtime.onMessage.removeListener(receiveListener);
+
+    if (receiveTimeout) clearTimeout(receiveTimeout);
+
+    return result;
   }
 }
 

--- a/api/background/utils.ts
+++ b/api/background/utils.ts
@@ -175,18 +175,19 @@ export class ApiUtils {
       browser.runtime.onMessage.addListener(receiveListener);
     });
 
-    const result = await Promise.race([onClosePromise, onMessagePromise]);
+    try {
+      const result = await Promise.race([onClosePromise, onMessagePromise]);
+      return result;
+    } finally {
+      // Ensure the listeners and timeout are cleaned up
+      if (onRemovedListener)
+        browser.windows.onRemoved.removeListener(onRemovedListener);
 
-    // Ensure the listeners and timeout are cleaned up
-    if (onRemovedListener)
-      browser.windows.onRemoved.removeListener(onRemovedListener);
+      if (receiveListener)
+        browser.runtime.onMessage.removeListener(receiveListener);
 
-    if (receiveListener)
-      browser.runtime.onMessage.removeListener(receiveListener);
-
-    if (receiveTimeout) clearTimeout(receiveTimeout);
-
-    return result;
+      if (receiveTimeout) clearTimeout(receiveTimeout);
+    }
   }
 }
 

--- a/components/layouts/BrowserAPILayout.tsx
+++ b/components/layouts/BrowserAPILayout.tsx
@@ -1,14 +1,8 @@
 import { Outlet } from "react-router-dom";
 import { POPUP_WINDOW_HEIGHT, POPUP_WINDOW_WIDTH } from "@/lib/utils";
 import { useEffect } from "react";
-import { ApiUtils } from "@/api/background/utils";
-import { ApiExtensionUtils } from "@/api/extension";
-import { useSearchParams } from "react-router-dom";
 
 export default function BrowserAPILayout() {
-  const [searchParams] = useSearchParams();
-  const requestId = searchParams.get("requestId") ?? "";
-
   // Resize the window to the target width and height for the popup
   useEffect(() => {
     const widthGap = POPUP_WINDOW_WIDTH - window.innerWidth;
@@ -17,23 +11,12 @@ export default function BrowserAPILayout() {
     window.resizeBy(widthGap, heightGap);
   }, []);
 
-  const denyMessage = ApiUtils.createApiResponse(
-    requestId,
-    false,
-    "User denied",
-  );
-
   useEffect(() => {
-    // Handle beforeunload event
-    async function beforeunload(event: BeforeUnloadEvent) {
-      await ApiExtensionUtils.sendMessage(requestId, denyMessage);
-    }
+    const timeout = setTimeout(() => {
+      window.close();
+    }, 60_000); // Close the popup after 60 seconds
 
-    window.addEventListener("beforeunload", beforeunload);
-
-    return () => {
-      window.removeEventListener("beforeunload", beforeunload);
-    };
+    return () => clearTimeout(timeout);
   }, []);
 
   return <Outlet />;


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

This PR fixes the bug that closing api popup window does not send message to provider.

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately

---

This pull request refactors the handling of browser popups and responses across multiple files to streamline the code and improve user experience. The changes include introducing a new utility method `openPopupAndListenForResponse`, replacing the previous `openPopup` and `receiveExtensionMessage` pattern, and simplifying popup timeout handling. Additionally, minor fixes and adjustments were made to improve consistency and correctness.

### Refactoring popup handling:

* [`api/background/utils.ts`](diffhunk://#diff-433adf60a262c9149f9fb36021171011f7305fe85de63dd573d2b5ee1009212cL131-R159): Added `openPopupAndListenForResponse`, which combines opening a popup and listening for its response, while handling timeout and cleanup. Removed the old `receiveExtensionMessage` method. [[1]](diffhunk://#diff-433adf60a262c9149f9fb36021171011f7305fe85de63dd573d2b5ee1009212cL131-R159) [[2]](diffhunk://#diff-433adf60a262c9149f9fb36021171011f7305fe85de63dd573d2b5ee1009212cL152-R189)
* Updated popup handling in various Ethereum handler files (`requestAccounts.ts`, `sendTransaction.ts`, `signMessage.ts`, `signTypedDataV4.ts`, `switchNetwork.ts`, `watchAsset.ts`) to use the new `openPopupAndListenForResponse` method. [[1]](diffhunk://#diff-39adc815c6f9f5e879761408acb6e08026ced4e18e66c26dbf3a5d7ea84ee142L28-R47) [[2]](diffhunk://#diff-36ba1cfa20d49571759c3cbd0258fba9ec4a83db6bf19b892369c99da5d7d15eL76-R81) [[3]](diffhunk://#diff-002b091481d0d1db80d58af5e168c3daef9308ead79862eb422eead73b286568L66-R71) [[4]](diffhunk://#diff-d59c6e8a18dd0fca759739b7d3f6455da65cae2093209a3ae5a8dd2af7872745L66-R71) [[5]](diffhunk://#diff-0d96aa7f6dd0f7ebc850326f6df443ce83dae582f7b4ca597f581dd63d714393L49-R54) [[6]](diffhunk://#diff-46b306f628b18e9c1cba4fed0c6acf3a1e0636bd5bb0525cd343ed399c91d243L110-R115)
* Updated popup handling in Kaspa handler files (`connect.ts`, `signAndBroadcastTx.ts`, `signMessage.ts`, `signTx.ts`, `switchNetwork.ts`) to use the new method. [[1]](diffhunk://#diff-b8ba94a2a9a2ef5723bfe8aa1dffae9444e7dedfaf8db0ced82ea05c3e975ab8L55-R60) [[2]](diffhunk://#diff-9ef36c662476a1355ea2f81f06538c84efe0bcf4424d976b016d1c54f4880b71L52-R57) [[3]](diffhunk://#diff-469e5d2c5909dcdfe7cc8062e7f02c2185d7970e3d872255b7823af5a6843ce1L60-R65) [[4]](diffhunk://#diff-9899f4ab19702c5515fbf8cd344a3c4b9cd692e97f53a150ea762a3fba149821L45-R50) [[5]](diffhunk://#diff-ab3baca198f0e31cb002986208ec23d066892745a12952a174dc73455211cbafL43-R48)

### Code cleanup and consistency improvements:

* [`api/background/utils.ts`](diffhunk://#diff-94e71f7d73a42ca577784ae909cf166bb0323414848d28639a115f73dc08b3e6L19-R19): Fixed the error message in `isUserDeniedResponse` to match the new format ("User denied").
* [`components/layouts/BrowserAPILayout.tsx`](diffhunk://#diff-5c772f9c3b91ae6f91de552394e877d221770b01d1165d97735b0a41ce6a09e6L4-L11): Simplified popup timeout handling by removing the `beforeunload` event and introducing a direct timeout to close the popup after 60 seconds. [[1]](diffhunk://#diff-5c772f9c3b91ae6f91de552394e877d221770b01d1165d97735b0a41ce6a09e6L4-L11) [[2]](diffhunk://#diff-5c772f9c3b91ae6f91de552394e877d221770b01d1165d97735b0a41ce6a09e6L20-R19)

### Minor adjustments:

* [`api/background/handlers/kaspa/getAccount.ts`](diffhunk://#diff-6f1eff81da730fc1fb5dd66d071f2d7fad0eda381bfb1710b5efed407865c4cbL2-R2): Removed unused import `ApiRequest`.
* [`api/background/utils.ts`](diffhunk://#diff-433adf60a262c9149f9fb36021171011f7305fe85de63dd573d2b5ee1009212cL23-R23): Ensured `openPopup` returns the created browser window object.