### PR TITLE
feat: improve content script injection performance for injected script

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -32,9 +32,6 @@ export default defineContentScript({
       window.postMessage(response, window.location.origin);
     });
 
-    // Inject the script that will add the window.kastle object
-    injectScript("/injected.js");
-
     // Emit the kastle_installed event to the page to notify that the extension is installed
     window.postMessage(
       ApiUtils.createApiResponse("kastle_installed", []),
@@ -47,4 +44,5 @@ export default defineContentScript({
     watchSettingsUpdated();
     watchWalletSettingsUpdated();
   },
+  runAt: "document_end",
 });

--- a/entrypoints/injector.ts
+++ b/entrypoints/injector.ts
@@ -1,0 +1,18 @@
+export default defineContentScript({
+  matches: ["*://*/*"],
+  main() {
+    if (document.documentElement) {
+      injectScript("/injected.js");
+    } else {
+      const observer = new MutationObserver((mutations, obs) => {
+        if (document.documentElement) {
+          obs.disconnect();
+          injectScript("/injected.js");
+        }
+      });
+
+      observer.observe(document, { childList: true });
+    }
+  },
+  runAt: "document_start",
+});

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -20,7 +20,13 @@ export default defineConfig({
     externally_connectable: {
       matches: ["*://*/*"],
     },
-    run_at: "document_start",
+    content_scripts: [
+      {
+        matches: ["*://*/*"],
+        js: ["/injector.js"],
+        run_at: "document_start",
+      },
+    ],
   },
   runner: {
     startUrls: ["https://forbole.github.io/kastle/"],


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately

---

This pull request introduces changes to improve the injection mechanism for the `window.kastle` object and adjusts the configuration for content scripts. The key updates include moving the injection logic to a dedicated `injector.ts` file, refining the script execution timing, and updating the extension's configuration to align with the new structure.

### Injection Mechanism Updates:

* [`entrypoints/content.ts`](diffhunk://#diff-8ce8b0bd9bcf8126ac7f1637f4042ae7f73a441c83098baa95a97dea642ce84bL35-L37): Removed the direct injection of the `/injected.js` script and added the `runAt: "document_end"` property to ensure proper timing for the content script execution. [[1]](diffhunk://#diff-8ce8b0bd9bcf8126ac7f1637f4042ae7f73a441c83098baa95a97dea642ce84bL35-L37) [[2]](diffhunk://#diff-8ce8b0bd9bcf8126ac7f1637f4042ae7f73a441c83098baa95a97dea642ce84bR47)
* [`entrypoints/injector.ts`](diffhunk://#diff-170c07b251030fb2f03ee81d9557917a77357f8a959496462118a23074c4e1f7R1-R18): Introduced a new file to handle the script injection logic, including observing mutations to ensure the script is injected even if `document.documentElement` is not immediately available. The script is set to run at `document_start` for early execution.

### Configuration Updates:

* [`wxt.config.ts`](diffhunk://#diff-09c55dc0ee48c836f078cf65fe7253e1713e78ed1aea44735a987bc581223766R23-R30): Updated the extension configuration to add the new `injector.js` as a content script, specifying `matches: ["*://*/*"]` and `run_at: "document_start"` for consistent behavior across all pages.