### PR TITLE
fix(api): fix sign message api

### DIFF
--- a/api/background/handlers/kaspa/signMessage.ts
+++ b/api/background/handlers/kaspa/signMessage.ts
@@ -3,9 +3,9 @@ import { ApiRequestWithHost, ApiResponse } from "@/api/message";
 import { ApiUtils } from "@/api/background/utils";
 import { z } from "zod";
 
-export const SignMessagePayloadSchema = z.object({
-  message: z.string(),
-});
+export const SignMessagePayloadSchema = z
+  .string()
+  .min(1, "Message cannot be empty");
 
 export type SignMessagePayload = z.infer<typeof SignMessagePayloadSchema>;
 
@@ -47,7 +47,7 @@ export const signMessageHandler: Handler = async (
   const result = SignMessagePayloadSchema.safeParse(message.payload);
   if (!result.success) {
     sendResponse(
-      ApiUtils.createApiResponse(message.id, null, "Invalid transaction data"),
+      ApiUtils.createApiResponse(message.id, null, "Invalid message data"),
     );
     return;
   }
@@ -55,7 +55,7 @@ export const signMessageHandler: Handler = async (
   const url = new URL(browser.runtime.getURL("/popup.html"));
   url.hash = "/sign-message";
   url.searchParams.set("requestId", message.id);
-  url.searchParams.set("payload", JSON.stringify(result.data));
+  url.searchParams.set("payload", result.data);
 
   // Open the popup and wait for the response
   const response = await ApiUtils.openPopupAndListenForResponse(

--- a/api/browser.ts
+++ b/api/browser.ts
@@ -61,6 +61,7 @@ export class KastleBrowserAPI {
       "kas:sign_tx": Action.SIGN_TX,
       "kas:sign_and_broadcast_tx": Action.SIGN_AND_BROADCAST_TX,
       "kas:switch_network": Action.SWITCH_NETWORK,
+      "kas:sign_message": Action.SIGN_MESSAGE,
     }[method];
 
     if (!action) {
@@ -126,9 +127,7 @@ export class KastleBrowserAPI {
     const request = createApiRequest(
       Action.SIGN_MESSAGE,
       requestId,
-      SignMessagePayloadSchema.parse({
-        message,
-      }),
+      SignMessagePayloadSchema.parse(message),
     );
     window.postMessage(request, "*");
 

--- a/components/screens/browser-api/kaspa/SignMessageConfirm.tsx
+++ b/components/screens/browser-api/kaspa/SignMessageConfirm.tsx
@@ -12,9 +12,7 @@ export default function SignMessageConfirm() {
     "payload",
   );
 
-  const payload = encodedPayload
-    ? JSON.parse(decodeURIComponent(encodedPayload))
-    : null;
+  const payload = encodedPayload ? decodeURIComponent(encodedPayload) : null;
 
   const parsedPayload = payload
     ? SignMessagePayloadSchema.parse(payload)

--- a/components/screens/browser-api/kaspa/sign-message/HotWalletSignMessage.tsx
+++ b/components/screens/browser-api/kaspa/sign-message/HotWalletSignMessage.tsx
@@ -51,7 +51,7 @@ export default function HotWalletSignMessage({
         <SignMessage
           walletSigner={wallet}
           requestId={requestId}
-          message={payload.message}
+          message={payload}
         />
       )}
     </>

--- a/components/screens/browser-api/kaspa/sign-message/LedgerSignMessage.tsx
+++ b/components/screens/browser-api/kaspa/sign-message/LedgerSignMessage.tsx
@@ -36,7 +36,7 @@ export default function LedgerSignMessage({
         <SignMessage
           walletSigner={wallet}
           requestId={requestId}
-          message={payload.message}
+          message={payload}
         />
       )}
     </>


### PR DESCRIPTION
<!-- PR_TEMPLATE.md -->

# Pull Request Checklist

## Before Submission

- [ ] I confirm this PR follows the [code standards](CONTRIBUTING.md#styleguides)
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] **I have read and agree to the [Contributor License Agreement](CLA.md)**

---

## Description

<!-- Clearly describe what this PR accomplishes -->

---

## Additional Notes

<!-- Add any context, screenshots, or implementation details -->

---

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the [Business Source License](LICENSE)
- [ ] I grant Forbole Technology Limited a perpetual, worldwide, non-exclusive license to use my contribution under the
      project's
      license terms
- [ ] I have the authority to make this contribution and license it appropriately

---

This pull request refines the handling of message signing in the Kaspa integration by improving schema validation, simplifying payload handling, and ensuring consistency across the API and UI components. The changes aim to streamline the codebase and enhance user experience.

### Schema Validation Improvements:
* Updated `SignMessagePayloadSchema` in `api/background/handlers/kaspa/signMessage.ts` to validate that the message is a non-empty string, providing clearer error feedback when the message is empty.

### API Enhancements:
* Added support for the `"kas:sign_message"` action in the `KastleBrowserAPI` class to enable message signing functionality.
* Simplified the `SignMessagePayloadSchema.parse` call in `KastleBrowserAPI` to directly parse the message string instead of wrapping it in an object.

### Payload Handling Simplifications:
* Removed unnecessary JSON parsing and encoding in `SignMessageConfirm.tsx` to directly decode the payload string.
* Updated `HotWalletSignMessage.tsx` and `LedgerSignMessage.tsx` to pass the entire payload directly to the `SignMessage` component, eliminating reliance on the `message` property. [[1]](diffhunk://#diff-3b9f2dbcd0088c746956a7b8626b0fc610ee3fe9585c5742ad6b7236e7963c1aL54-R54) [[2]](diffhunk://#diff-32aa0f5aee7e7ca47afff485719de6614e475d861646296eb07d092d2a4a5ea9L39-R39)

### Error Message Refinement:
* Adjusted error messages in `signMessageHandler` to use "Invalid message data" for better alignment with the operation being performed.
