### PR TITLE
feat: add Custom RPC settings UI

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "node_modules/.bin/storybook",
+      "runtimeArgs": ["dev", "-p", "6007", "--ci"],
+      "port": 6007
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "flag-icons": "^7.3.2",
         "hash-wasm": "^4.12.0",
         "hw-app-kaspa": "github:coderofstuff/hw-app-kaspa#v1.2.1",
+        "lucide-react": "^1.24.0",
         "posthog-js-lite": "^3.3.0",
         "preline": "^2.7.0",
         "qrcode": "^1.5.4",
@@ -9793,6 +9794,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "flag-icons": "^7.3.2",
     "hash-wasm": "^4.12.0",
     "hw-app-kaspa": "github:coderofstuff/hw-app-kaspa#v1.2.1",
+    "lucide-react": "^1.24.0",
     "posthog-js-lite": "^3.3.0",
     "preline": "^2.7.0",
     "qrcode": "^1.5.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
         "icy-blue": {
           50: "#ebffef",
           100: "#cefbf",
-          200: "#a2f5f",
+          200: "#a2f5ff",
           300: "#63eafd",
           400: "#00b1d0",
           500: "#0a7694",

--- a/ui/general/ActionSheet.stories.tsx
+++ b/ui/general/ActionSheet.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import ActionSheet from "./ActionSheet";
-import AddCustomNodeForm from "../popup/custom-rpc/AddCustomNodeForm";
+import AddCustomNodeForm from "@/ui/popup/custom-rpc/AddCustomNodeForm";
 
 const meta: Meta<typeof ActionSheet> = {
   title: "General/ActionSheet",

--- a/ui/general/ActionSheet.stories.tsx
+++ b/ui/general/ActionSheet.stories.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import ActionSheet from "./ActionSheet";
+import AddCustomNodeForm from "../popup/custom-rpc/AddCustomNodeForm";
+
+const meta: Meta<typeof ActionSheet> = {
+  title: "General/ActionSheet",
+  component: ActionSheet,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative h-[600px] w-[375px] overflow-hidden bg-icy-blue-950 font-sans text-white">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onClose: { action: "close" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionSheet>;
+
+/** ActionSheet is a generic overlay shell — it only renders a backdrop + sliding sheet frame.
+ * Real content (e.g. AddCustomNodeForm below) is passed in as children by the consumer. */
+export const Open: Story = {
+  render: () => {
+    function Wrapper() {
+      const [name, setName] = useState("");
+      const [url, setUrl] = useState("");
+      return (
+        <ActionSheet isOpen>
+          <AddCustomNodeForm
+            name={name}
+            url={url}
+            onNameChange={setName}
+            onUrlChange={setUrl}
+            onSubmit={() => {}}
+          />
+        </ActionSheet>
+      );
+    }
+    return <Wrapper />;
+  },
+};

--- a/ui/general/ActionSheet.tsx
+++ b/ui/general/ActionSheet.tsx
@@ -1,0 +1,21 @@
+export interface ActionSheetProps {
+  isOpen: boolean;
+  onClose?: () => void;
+  children: React.ReactNode;
+}
+
+export default function ActionSheet({ isOpen, onClose, children }: ActionSheetProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute inset-0 z-10 flex flex-col justify-end">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative rounded-t-3xl border border-daintree-700 bg-daintree-800 px-5 pb-8 pt-2">
+        <div className="flex justify-center py-1">
+          <div className="h-1 w-16 rounded-full bg-daintree-600" />
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/ui/general/ActionSheet.tsx
+++ b/ui/general/ActionSheet.tsx
@@ -4,7 +4,11 @@ export interface ActionSheetProps {
   children: React.ReactNode;
 }
 
-export default function ActionSheet({ isOpen, onClose, children }: ActionSheetProps) {
+export default function ActionSheet({
+  isOpen,
+  onClose,
+  children,
+}: ActionSheetProps) {
   if (!isOpen) return null;
 
   return (

--- a/ui/general/Button.stories.tsx
+++ b/ui/general/Button.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Button from "./Button";
+
+const meta: Meta<typeof Button> = {
+  title: "General/Button",
+  component: Button,
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] bg-icy-blue-950 p-4 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onClick: { action: "click" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const PrimaryMd: Story = {
+  args: {
+    children: "Done",
+    variant: "primary",
+    size: "md",
+  },
+};
+
+export const PrimaryLg: Story = {
+  args: {
+    children: "Add",
+    variant: "primary",
+    size: "lg",
+  },
+};
+
+export const SecondaryMd: Story = {
+  args: {
+    children: "Add custom node",
+    variant: "secondary",
+    size: "md",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Add",
+    variant: "primary",
+    size: "lg",
+    disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    children: "Add",
+    variant: "primary",
+    size: "lg",
+    loading: true,
+  },
+};

--- a/ui/general/Button.tsx
+++ b/ui/general/Button.tsx
@@ -1,0 +1,46 @@
+import { twMerge } from "tailwind-merge";
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  variant?: "primary" | "secondary";
+  /** md = 46px (bottom nav actions like "Add custom node" / "Done"); lg = 62px (form CTA like "Add"). */
+  size?: "md" | "lg";
+  disabled?: boolean;
+  loading?: boolean;
+  onClick?: () => void;
+  type?: "button" | "submit";
+}
+
+export default function Button({
+  children,
+  variant = "primary",
+  size = "md",
+  disabled = false,
+  loading = false,
+  onClick,
+  type = "button",
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      disabled={disabled || loading}
+      className={twMerge(
+        "flex w-full items-center justify-center rounded-full text-sm font-semibold text-white",
+        size === "md" ? "h-[46px]" : "h-[62px]",
+        variant === "primary" ? "bg-icy-blue-400" : "border border-white",
+        (disabled || loading) && "opacity-60",
+      )}
+    >
+      {loading ? (
+        <span
+          role="status"
+          aria-label="loading"
+          className="inline-block size-5 animate-spin self-center rounded-full border-[3px] border-current border-t-[#A2F5FF] text-icy-blue-600"
+        />
+      ) : (
+        children
+      )}
+    </button>
+  );
+}

--- a/ui/general/Button.tsx
+++ b/ui/general/Button.tsx
@@ -36,7 +36,7 @@ export default function Button({
         <span
           role="status"
           aria-label="loading"
-          className="inline-block size-5 animate-spin self-center rounded-full border-[3px] border-current border-t-[#A2F5FF] text-icy-blue-600"
+          className="inline-block size-5 animate-spin self-center rounded-full border-[3px] border-current border-t-icy-blue-200 text-icy-blue-600"
         />
       ) : (
         children

--- a/ui/general/PageHeader.stories.tsx
+++ b/ui/general/PageHeader.stories.tsx
@@ -17,6 +17,7 @@ const meta: Meta<typeof PageHeader> = {
     showClose: { control: "boolean" },
     onBack: { action: "back" },
     onClose: { action: "close" },
+    onRightAction: { action: "rightAction" },
   },
 };
 
@@ -53,5 +54,14 @@ export const TitleOnly: Story = {
     title: "Page Title",
     showBack: false,
     showClose: false,
+  },
+};
+
+export const WithRightAction: Story = {
+  args: {
+    title: "Custom RPC",
+    subtitle: "The node Kastle uses to reach Kaspa.",
+    showBack: true,
+    rightIcon: "hn hn-pencil",
   },
 };

--- a/ui/general/PageHeader.tsx
+++ b/ui/general/PageHeader.tsx
@@ -5,6 +5,9 @@ export interface PageHeaderProps {
   showClose?: boolean;
   onBack?: () => void;
   onClose?: () => void;
+  /** Icon class for a right-side action button (e.g. "hn hn-pencil"). Takes precedence over showClose. */
+  rightIcon?: string;
+  onRightAction?: () => void;
   paddingX?: string;
   paddingBottom?: string;
 }
@@ -16,6 +19,8 @@ export default function PageHeader({
   showClose = false,
   onBack,
   onClose,
+  rightIcon,
+  onRightAction,
   paddingX = "px-4",
   paddingBottom = "pb-0",
 }: PageHeaderProps) {
@@ -43,13 +48,22 @@ export default function PageHeader({
           )}
         </div>
         <div className="w-[46px]">
-          {showClose && (
+          {rightIcon ? (
             <button
               className="flex size-[46px] items-center justify-center rounded-lg text-white hover:bg-daintree-800"
-              onClick={onClose}
+              onClick={onRightAction}
             >
-              <i className="hn hn-times text-xl" />
+              <i className={`${rightIcon} text-xl`} />
             </button>
+          ) : (
+            showClose && (
+              <button
+                className="flex size-[46px] items-center justify-center rounded-lg text-white hover:bg-daintree-800"
+                onClick={onClose}
+              >
+                <i className="hn hn-times text-xl" />
+              </button>
+            )
           )}
         </div>
       </div>

--- a/ui/general/SegmentedControl.stories.tsx
+++ b/ui/general/SegmentedControl.stories.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import SegmentedControl from "./SegmentedControl";
+
+const meta: Meta<typeof SegmentedControl> = {
+  title: "General/SegmentedControl",
+  component: SegmentedControl,
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] bg-icy-blue-950 p-4 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SegmentedControl>;
+
+export const MainnetTestnet: Story = {
+  render: () => {
+    function Wrapper() {
+      const [value, setValue] = useState("mainnet");
+      return (
+        <SegmentedControl
+          options={[
+            { label: "Mainnet", value: "mainnet" },
+            { label: "Testnet", value: "testnet" },
+          ]}
+          value={value}
+          onChange={setValue}
+        />
+      );
+    }
+    return <Wrapper />;
+  },
+};

--- a/ui/general/SegmentedControl.tsx
+++ b/ui/general/SegmentedControl.tsx
@@ -1,0 +1,38 @@
+import { twMerge } from "tailwind-merge";
+
+export interface SegmentedOption<T extends string> {
+  label: string;
+  value: T;
+}
+
+export interface SegmentedControlProps<T extends string> {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+export default function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: SegmentedControlProps<T>) {
+  return (
+    <div className="flex justify-center">
+      <div className="flex gap-1 rounded-full border border-daintree-700 p-1">
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={twMerge(
+              "h-9 rounded-full px-3.5 text-sm font-medium text-gray-200",
+              value === opt.value && "bg-white/10",
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/popup/custom-rpc/AddCustomNodeForm.stories.tsx
+++ b/ui/popup/custom-rpc/AddCustomNodeForm.stories.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import ActionSheet from "../../general/ActionSheet";
+import AddCustomNodeForm from "./AddCustomNodeForm";
+
+const meta: Meta<typeof AddCustomNodeForm> = {
+  title: "Popup/CustomRpc/Components/AddCustomNodeForm",
+  component: AddCustomNodeForm,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative h-[600px] w-[375px] overflow-hidden bg-icy-blue-950 font-sans text-white">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onSubmit: { action: "submit" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddCustomNodeForm>;
+
+function InteractiveTemplate({
+  initialName = "",
+  initialUrl = "",
+  urlError,
+  submitting = false,
+}: {
+  initialName?: string;
+  initialUrl?: string;
+  urlError?: string;
+  submitting?: boolean;
+}) {
+  const [name, setName] = useState(initialName);
+  const [url, setUrl] = useState(initialUrl);
+
+  return (
+    <ActionSheet isOpen>
+      <AddCustomNodeForm
+        name={name}
+        url={url}
+        onNameChange={setName}
+        onUrlChange={setUrl}
+        urlError={urlError}
+        submitting={submitting}
+        onSubmit={() => {}}
+      />
+    </ActionSheet>
+  );
+}
+
+export const Empty: Story = {
+  render: () => <InteractiveTemplate />,
+};
+
+export const Filled: Story = {
+  render: () => (
+    <InteractiveTemplate
+      initialName="Community node"
+      initialUrl="community-node37814791hdsahdvcxvjsahk2.com"
+    />
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <InteractiveTemplate
+      initialName="Community node"
+      initialUrl="Community-node37814791hdsahdvcxvjsahk2.c"
+      urlError="Enter a valid WebSocket address (ws:// or wss://)"
+    />
+  ),
+};
+
+export const Submitting: Story = {
+  render: () => (
+    <InteractiveTemplate
+      initialName="Community node"
+      initialUrl="community-node37814791hdsahdvcxvjsahk2.com"
+      submitting
+    />
+  ),
+};

--- a/ui/popup/custom-rpc/AddCustomNodeForm.stories.tsx
+++ b/ui/popup/custom-rpc/AddCustomNodeForm.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import ActionSheet from "../../general/ActionSheet";
+import ActionSheet from "@/ui/general/ActionSheet";
 import AddCustomNodeForm from "./AddCustomNodeForm";
 
 const meta: Meta<typeof AddCustomNodeForm> = {

--- a/ui/popup/custom-rpc/AddCustomNodeForm.tsx
+++ b/ui/popup/custom-rpc/AddCustomNodeForm.tsx
@@ -21,7 +21,8 @@ export default function AddCustomNodeForm({
   submitting = false,
   onSubmit,
 }: AddCustomNodeFormProps) {
-  const canSubmit = name.trim().length > 0 && url.trim().length > 0 && !submitting;
+  const canSubmit =
+    name.trim().length > 0 && url.trim().length > 0 && !submitting;
 
   return (
     <div className="flex flex-col pt-3">
@@ -32,7 +33,10 @@ export default function AddCustomNodeForm({
       <div className="mt-3 h-px bg-daintree-700" />
 
       <div className="mt-4 flex flex-col gap-1.5">
-        <label htmlFor="node-name" className="text-sm font-semibold text-gray-200">
+        <label
+          htmlFor="node-name"
+          className="text-sm font-semibold text-gray-200"
+        >
           Node Name
         </label>
         <input
@@ -47,7 +51,10 @@ export default function AddCustomNodeForm({
       </div>
 
       <div className="mt-4 flex flex-col gap-1.5">
-        <label htmlFor="rpc-url" className="text-sm font-semibold text-gray-200">
+        <label
+          htmlFor="rpc-url"
+          className="text-sm font-semibold text-gray-200"
+        >
           RPC URL
         </label>
         <input
@@ -66,7 +73,13 @@ export default function AddCustomNodeForm({
       </div>
 
       <div className="mt-5">
-        <Button variant="primary" size="lg" disabled={!canSubmit} loading={submitting} onClick={onSubmit}>
+        <Button
+          variant="primary"
+          size="lg"
+          disabled={!canSubmit}
+          loading={submitting}
+          onClick={onSubmit}
+        >
           Add
         </Button>
       </div>

--- a/ui/popup/custom-rpc/AddCustomNodeForm.tsx
+++ b/ui/popup/custom-rpc/AddCustomNodeForm.tsx
@@ -1,0 +1,72 @@
+import { twMerge } from "tailwind-merge";
+import Button from "../../general/Button";
+
+export interface AddCustomNodeFormProps {
+  name: string;
+  url: string;
+  onNameChange: (value: string) => void;
+  onUrlChange: (value: string) => void;
+  /** Error message shown under the RPC URL field, e.g. "Enter a valid WebSocket address (ws:// or wss://)". */
+  urlError?: string;
+  submitting?: boolean;
+  onSubmit: () => void;
+}
+
+export default function AddCustomNodeForm({
+  name,
+  url,
+  onNameChange,
+  onUrlChange,
+  urlError,
+  submitting = false,
+  onSubmit,
+}: AddCustomNodeFormProps) {
+  const canSubmit = name.trim().length > 0 && url.trim().length > 0 && !submitting;
+
+  return (
+    <div className="flex flex-col pt-3">
+      <h2 className="text-lg font-semibold text-gray-200">Add custom node</h2>
+      <p className="mt-1 text-sm text-daintree-400">
+        Connect Kastle to your own Kaspa node.
+      </p>
+      <div className="mt-3 h-px bg-daintree-700" />
+
+      <div className="mt-4 flex flex-col gap-1.5">
+        <label className="text-sm font-semibold text-gray-200">Node Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          disabled={submitting}
+          placeholder="Home node"
+          className="h-[46px] rounded-lg border border-daintree-700 bg-icy-blue-950 px-4 text-sm font-medium text-white placeholder:text-daintree-400 focus:outline-none"
+        />
+      </div>
+
+      <div className="mt-4 flex flex-col gap-1.5">
+        <label className="text-sm font-semibold text-gray-200">RPC URL</label>
+        <input
+          type="text"
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          disabled={submitting}
+          placeholder="ws:// or wss://"
+          className={twMerge(
+            "h-[46px] rounded-lg border bg-icy-blue-950 px-4 text-sm font-medium text-white placeholder:text-daintree-400 focus:outline-none",
+            urlError ? "border-red-500" : "border-daintree-700",
+          )}
+        />
+        <p className="h-5 text-sm font-medium text-red-500">{urlError}</p>
+      </div>
+
+      <div className="mt-5">
+        <Button variant="primary" size="lg" disabled={!canSubmit} loading={submitting} onClick={onSubmit}>
+          Add
+        </Button>
+      </div>
+      <p className="mt-4 text-center text-xs text-daintree-400">
+        Only add a node you trust.
+      </p>
+    </div>
+  );
+}

--- a/ui/popup/custom-rpc/AddCustomNodeForm.tsx
+++ b/ui/popup/custom-rpc/AddCustomNodeForm.tsx
@@ -1,5 +1,5 @@
 import { twMerge } from "tailwind-merge";
-import Button from "../../general/Button";
+import Button from "@/ui/general/Button";
 
 export interface AddCustomNodeFormProps {
   name: string;
@@ -32,8 +32,11 @@ export default function AddCustomNodeForm({
       <div className="mt-3 h-px bg-daintree-700" />
 
       <div className="mt-4 flex flex-col gap-1.5">
-        <label className="text-sm font-semibold text-gray-200">Node Name</label>
+        <label htmlFor="node-name" className="text-sm font-semibold text-gray-200">
+          Node Name
+        </label>
         <input
+          id="node-name"
           type="text"
           value={name}
           onChange={(e) => onNameChange(e.target.value)}
@@ -44,8 +47,11 @@ export default function AddCustomNodeForm({
       </div>
 
       <div className="mt-4 flex flex-col gap-1.5">
-        <label className="text-sm font-semibold text-gray-200">RPC URL</label>
+        <label htmlFor="rpc-url" className="text-sm font-semibold text-gray-200">
+          RPC URL
+        </label>
         <input
+          id="rpc-url"
           type="text"
           value={url}
           onChange={(e) => onUrlChange(e.target.value)}

--- a/ui/popup/custom-rpc/CustomRpcPage.stories.tsx
+++ b/ui/popup/custom-rpc/CustomRpcPage.stories.tsx
@@ -56,17 +56,23 @@ function InteractiveTemplate({
   const [network, setNetwork] = useState<RpcNetwork>("mainnet");
   const [mainnetNodes, setMainnetNodes] = useState(initialMainnetNodes);
   const [testnetNodes, setTestnetNodes] = useState(initialTestnetNodes);
-  const [mainnetSelected, setMainnetSelected] = useState(initialMainnetNodes[0]?.id ?? "");
-  const [testnetSelected, setTestnetSelected] = useState(initialTestnetNodes[0]?.id ?? "");
+  const [mainnetSelected, setMainnetSelected] = useState(
+    initialMainnetNodes[0]?.id ?? "",
+  );
+  const [testnetSelected, setTestnetSelected] = useState(
+    initialTestnetNodes[0]?.id ?? "",
+  );
   const [editMode, setEditMode] = useState(initialEditMode);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [addName, setAddName] = useState("");
   const [addUrl, setAddUrl] = useState("");
 
   const nodes = network === "mainnet" ? mainnetNodes : testnetNodes;
-  const selectedNodeId = network === "mainnet" ? mainnetSelected : testnetSelected;
+  const selectedNodeId =
+    network === "mainnet" ? mainnetSelected : testnetSelected;
   const setNodes = network === "mainnet" ? setMainnetNodes : setTestnetNodes;
-  const setSelectedNodeId = network === "mainnet" ? setMainnetSelected : setTestnetSelected;
+  const setSelectedNodeId =
+    network === "mainnet" ? setMainnetSelected : setTestnetSelected;
 
   return (
     <CustomRpcPage
@@ -86,7 +92,10 @@ function InteractiveTemplate({
       onAddNameChange={setAddName}
       onAddUrlChange={setAddUrl}
       onAddSubmit={() => {
-        setNodes((prev) => [...prev, { id: addUrl, name: addName, url: addUrl }]);
+        setNodes((prev) => [
+          ...prev,
+          { id: addUrl, name: addName, url: addUrl },
+        ]);
         setAddName("");
         setAddUrl("");
         setIsAddOpen(false);
@@ -101,7 +110,9 @@ export const DefaultOnly: Story = {
 
 export const WithCustomNodes: Story = {
   render: () => (
-    <InteractiveTemplate initialMainnetNodes={[mainnetDefault, mainnetCommunity]} />
+    <InteractiveTemplate
+      initialMainnetNodes={[mainnetDefault, mainnetCommunity]}
+    />
   ),
 };
 

--- a/ui/popup/custom-rpc/CustomRpcPage.stories.tsx
+++ b/ui/popup/custom-rpc/CustomRpcPage.stories.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import CustomRpcPage, { RpcNetwork, RpcNode } from "./CustomRpcPage";
+
+const meta: Meta<typeof CustomRpcPage> = {
+  title: "Popup/CustomRpc/Screens/CustomRpcPage",
+  component: CustomRpcPage,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative h-[600px] w-[375px] overflow-hidden bg-icy-blue-950 font-sans text-white">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onBack: { action: "back" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomRpcPage>;
+
+const mainnetDefault: RpcNode = {
+  id: "mainnet-default",
+  name: "Kastle node",
+  url: "kastle-mainnet-borsh.rhyzome.co",
+  isDefault: true,
+};
+
+const mainnetCommunity: RpcNode = {
+  id: "mainnet-community",
+  name: "Community node",
+  url: "community-node.com",
+};
+
+const testnetDefault: RpcNode = {
+  id: "testnet-default",
+  name: "Kastle node",
+  url: "kastle-testnet-borsh.rhyzome.co",
+  isDefault: true,
+};
+
+/** Per-network state is fully independent — switching tabs swaps the whole list + selection, like navigating to a different node-list route. */
+function InteractiveTemplate({
+  initialMainnetNodes,
+  initialTestnetNodes = [testnetDefault],
+  initialEditMode = false,
+}: {
+  initialMainnetNodes: RpcNode[];
+  initialTestnetNodes?: RpcNode[];
+  initialEditMode?: boolean;
+}) {
+  const [network, setNetwork] = useState<RpcNetwork>("mainnet");
+  const [mainnetNodes, setMainnetNodes] = useState(initialMainnetNodes);
+  const [testnetNodes, setTestnetNodes] = useState(initialTestnetNodes);
+  const [mainnetSelected, setMainnetSelected] = useState(initialMainnetNodes[0]?.id ?? "");
+  const [testnetSelected, setTestnetSelected] = useState(initialTestnetNodes[0]?.id ?? "");
+  const [editMode, setEditMode] = useState(initialEditMode);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addUrl, setAddUrl] = useState("");
+
+  const nodes = network === "mainnet" ? mainnetNodes : testnetNodes;
+  const selectedNodeId = network === "mainnet" ? mainnetSelected : testnetSelected;
+  const setNodes = network === "mainnet" ? setMainnetNodes : setTestnetNodes;
+  const setSelectedNodeId = network === "mainnet" ? setMainnetSelected : setTestnetSelected;
+
+  return (
+    <CustomRpcPage
+      network={network}
+      onNetworkChange={setNetwork}
+      nodes={nodes}
+      selectedNodeId={selectedNodeId}
+      onSelectNode={setSelectedNodeId}
+      editMode={editMode}
+      onToggleEdit={() => setEditMode((v) => !v)}
+      onRemoveNode={(id) => setNodes((prev) => prev.filter((n) => n.id !== id))}
+      isAddOpen={isAddOpen}
+      onOpenAdd={() => setIsAddOpen(true)}
+      onCloseAdd={() => setIsAddOpen(false)}
+      addName={addName}
+      addUrl={addUrl}
+      onAddNameChange={setAddName}
+      onAddUrlChange={setAddUrl}
+      onAddSubmit={() => {
+        setNodes((prev) => [...prev, { id: addUrl, name: addName, url: addUrl }]);
+        setAddName("");
+        setAddUrl("");
+        setIsAddOpen(false);
+      }}
+    />
+  );
+}
+
+export const DefaultOnly: Story = {
+  render: () => <InteractiveTemplate initialMainnetNodes={[mainnetDefault]} />,
+};
+
+export const WithCustomNodes: Story = {
+  render: () => (
+    <InteractiveTemplate initialMainnetNodes={[mainnetDefault, mainnetCommunity]} />
+  ),
+};
+
+export const EditMode: Story = {
+  render: () => (
+    <InteractiveTemplate
+      initialMainnetNodes={[mainnetDefault, mainnetCommunity]}
+      initialEditMode
+    />
+  ),
+};

--- a/ui/popup/custom-rpc/CustomRpcPage.tsx
+++ b/ui/popup/custom-rpc/CustomRpcPage.tsx
@@ -1,7 +1,7 @@
-import PageHeader from "../../general/PageHeader";
-import SegmentedControl from "../../general/SegmentedControl";
-import ActionSheet from "../../general/ActionSheet";
-import Button from "../../general/Button";
+import PageHeader from "@/ui/general/PageHeader";
+import SegmentedControl from "@/ui/general/SegmentedControl";
+import ActionSheet from "@/ui/general/ActionSheet";
+import Button from "@/ui/general/Button";
 import NodeListItem from "./NodeListItem";
 import AddCustomNodeForm from "./AddCustomNodeForm";
 

--- a/ui/popup/custom-rpc/CustomRpcPage.tsx
+++ b/ui/popup/custom-rpc/CustomRpcPage.tsx
@@ -1,0 +1,122 @@
+import PageHeader from "../../general/PageHeader";
+import SegmentedControl from "../../general/SegmentedControl";
+import ActionSheet from "../../general/ActionSheet";
+import Button from "../../general/Button";
+import NodeListItem from "./NodeListItem";
+import AddCustomNodeForm from "./AddCustomNodeForm";
+
+export interface RpcNode {
+  id: string;
+  name: string;
+  url: string;
+  isDefault?: boolean;
+}
+
+export type RpcNetwork = "mainnet" | "testnet";
+
+export interface CustomRpcPageProps {
+  network: RpcNetwork;
+  onNetworkChange: (network: RpcNetwork) => void;
+  /** Node list for the currently active network — swap this when network changes. */
+  nodes: RpcNode[];
+  selectedNodeId: string;
+  onSelectNode: (id: string) => void;
+  /** Edit mode — rows show a remove control (default node excluded); the bottom button becomes "Done". */
+  editMode?: boolean;
+  onToggleEdit?: () => void;
+  onRemoveNode?: (id: string) => void;
+  onBack?: () => void;
+
+  isAddOpen: boolean;
+  onOpenAdd: () => void;
+  onCloseAdd: () => void;
+  addName: string;
+  addUrl: string;
+  onAddNameChange: (value: string) => void;
+  onAddUrlChange: (value: string) => void;
+  addUrlError?: string;
+  isAddSubmitting?: boolean;
+  onAddSubmit: () => void;
+}
+
+export default function CustomRpcPage({
+  network,
+  onNetworkChange,
+  nodes,
+  selectedNodeId,
+  onSelectNode,
+  editMode = false,
+  onToggleEdit,
+  onRemoveNode,
+  onBack,
+  isAddOpen,
+  onOpenAdd,
+  onCloseAdd,
+  addName,
+  addUrl,
+  onAddNameChange,
+  onAddUrlChange,
+  addUrlError,
+  isAddSubmitting,
+  onAddSubmit,
+}: CustomRpcPageProps) {
+  return (
+    <div className="relative flex h-full flex-col bg-icy-blue-950 font-sans text-white">
+      <PageHeader
+        title="Custom RPC"
+        subtitle="The node Kastle uses to reach Kaspa."
+        paddingBottom="pb-4"
+        onBack={onBack}
+        rightIcon={editMode ? undefined : "hn hn-pencil"}
+        onRightAction={onToggleEdit}
+      />
+      <div className="flex flex-1 flex-col gap-5 px-4">
+        <SegmentedControl
+          options={[
+            { label: "Mainnet", value: "mainnet" as const },
+            { label: "Testnet", value: "testnet" as const },
+          ]}
+          value={network}
+          onChange={onNetworkChange}
+        />
+        <div className="flex flex-col">
+          {nodes.map((node) => (
+            <NodeListItem
+              key={node.id}
+              name={node.name}
+              url={node.url}
+              isDefault={node.isDefault}
+              selected={node.id === selectedNodeId}
+              editMode={editMode}
+              onSelect={() => onSelectNode(node.id)}
+              onRemove={() => onRemoveNode?.(node.id)}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="px-4 pb-6 pt-3">
+        {editMode ? (
+          <Button variant="primary" size="md" onClick={onToggleEdit}>
+            Done
+          </Button>
+        ) : (
+          <Button variant="secondary" size="md" onClick={onOpenAdd}>
+            Add custom node
+          </Button>
+        )}
+      </div>
+
+      <ActionSheet isOpen={isAddOpen} onClose={onCloseAdd}>
+        <AddCustomNodeForm
+          name={addName}
+          url={addUrl}
+          onNameChange={onAddNameChange}
+          onUrlChange={onAddUrlChange}
+          urlError={addUrlError}
+          submitting={isAddSubmitting}
+          onSubmit={onAddSubmit}
+        />
+      </ActionSheet>
+    </div>
+  );
+}

--- a/ui/popup/custom-rpc/NodeListItem.stories.tsx
+++ b/ui/popup/custom-rpc/NodeListItem.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NodeListItem from "./NodeListItem";
+
+const meta: Meta<typeof NodeListItem> = {
+  title: "Popup/CustomRpc/Components/NodeListItem",
+  component: NodeListItem,
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] bg-icy-blue-950 p-4 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onSelect: { action: "select" },
+    onRemove: { action: "remove" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NodeListItem>;
+
+export const DefaultSelected: Story = {
+  args: {
+    name: "Kastle node",
+    url: "kastle-mainnet-borsh.rhyzome.co",
+    isDefault: true,
+    selected: true,
+  },
+};
+
+export const CustomUnselected: Story = {
+  args: {
+    name: "Community node",
+    url: "community-node.com",
+    selected: false,
+  },
+};
+
+export const EditModeCustom: Story = {
+  args: {
+    name: "Community node",
+    url: "community-node.com",
+    editMode: true,
+  },
+};
+
+export const EditModeDefault: Story = {
+  args: {
+    name: "Kastle node",
+    url: "kastle-mainnet-borsh.rhyzome.co",
+    isDefault: true,
+    editMode: true,
+  },
+};

--- a/ui/popup/custom-rpc/NodeListItem.tsx
+++ b/ui/popup/custom-rpc/NodeListItem.tsx
@@ -1,0 +1,65 @@
+import { Box, Check, Minus } from "lucide-react";
+
+export interface NodeListItemProps {
+  name: string;
+  url: string;
+  /** Built-in / default node — cannot be removed. */
+  isDefault?: boolean;
+  selected?: boolean;
+  /** Edit mode — shows a remove control (custom nodes only). */
+  editMode?: boolean;
+  onSelect?: () => void;
+  onRemove?: () => void;
+}
+
+export default function NodeListItem({
+  name,
+  url,
+  isDefault = false,
+  selected = false,
+  editMode = false,
+  onSelect,
+  onRemove,
+}: NodeListItemProps) {
+  const canSelect = !editMode && !!onSelect;
+
+  return (
+    <div
+      onClick={canSelect ? onSelect : undefined}
+      role={canSelect ? "button" : undefined}
+      className="flex w-full items-center gap-3 rounded-lg py-3.5"
+    >
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-icy-blue-900">
+        <Box size={20} className="text-daintree-400" strokeWidth={2} />
+      </div>
+      <div className="flex flex-1 flex-col gap-0.5 text-left">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold text-white">{name}</span>
+          {isDefault && (
+            <span className="shrink-0 rounded-full bg-daintree-700 px-2 py-0.5 text-xs text-daintree-300">
+              Default
+            </span>
+          )}
+        </div>
+        <span className="truncate text-xs text-daintree-400">{url}</span>
+      </div>
+      {editMode ? (
+        !isDefault && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="flex size-4 shrink-0 items-center justify-center rounded-full bg-red-500"
+          >
+            <Minus size={10} className="text-white" strokeWidth={3} />
+          </button>
+        )
+      ) : selected ? (
+        <div className="flex size-4 shrink-0 items-center justify-center rounded-full bg-icy-blue-400">
+          <Check size={10} className="text-white" strokeWidth={3} />
+        </div>
+      ) : (
+        <div className="size-4 shrink-0 rounded-full border border-daintree-700" />
+      )}
+    </div>
+  );
+}

--- a/ui/popup/custom-rpc/NodeListItem.tsx
+++ b/ui/popup/custom-rpc/NodeListItem.tsx
@@ -26,7 +26,18 @@ export default function NodeListItem({
   return (
     <div
       onClick={canSelect ? onSelect : undefined}
+      onKeyDown={
+        canSelect
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect?.();
+              }
+            }
+          : undefined
+      }
       role={canSelect ? "button" : undefined}
+      tabIndex={canSelect ? 0 : undefined}
       className="flex w-full items-center gap-3 rounded-lg py-3.5"
     >
       <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-icy-blue-900">

--- a/ui/popup/custom-rpc/NodeListItem.tsx
+++ b/ui/popup/custom-rpc/NodeListItem.tsx
@@ -45,7 +45,9 @@ export default function NodeListItem({
       </div>
       <div className="flex flex-1 flex-col gap-0.5 text-left">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-semibold text-white">{name}</span>
+          <span className="truncate text-sm font-semibold text-white">
+            {name}
+          </span>
           {isDefault && (
             <span className="shrink-0 rounded-full bg-daintree-700 px-2 py-0.5 text-xs text-daintree-300">
               Default

--- a/ui/popup/settings/CustomRpcSettingsSection.stories.tsx
+++ b/ui/popup/settings/CustomRpcSettingsSection.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import CustomRpcSettingsSection from "./CustomRpcSettingsSection";
+
+const meta: Meta<typeof CustomRpcSettingsSection> = {
+  title: "Popup/Settings/Components/CustomRpcSettingsSection",
+  component: CustomRpcSettingsSection,
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] bg-icy-blue-950 p-4 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onNetworkClick: { action: "networkClick" },
+    onCustomRpcClick: { action: "customRpcClick" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CustomRpcSettingsSection>;
+
+export const Default: Story = {
+  args: {
+    networkValue: "Mainnet",
+    customRpcValue: "Default",
+  },
+};
+
+export const CustomNodeActive: Story = {
+  args: {
+    networkValue: "Mainnet",
+    customRpcValue: "Home node",
+  },
+};
+
+export const LongNodeName: Story = {
+  args: {
+    networkValue: "Testnet",
+    customRpcValue: "A very long node's name...",
+  },
+};

--- a/ui/popup/settings/CustomRpcSettingsSection.tsx
+++ b/ui/popup/settings/CustomRpcSettingsSection.tsx
@@ -1,0 +1,33 @@
+import SettingRow from "./SettingRow";
+
+export interface CustomRpcSettingsSectionProps {
+  /** e.g. "Mainnet" / "Testnet". */
+  networkValue: string;
+  /** "Default" or the active custom node's name. */
+  customRpcValue: string;
+  onNetworkClick?: () => void;
+  onCustomRpcClick?: () => void;
+}
+
+export default function CustomRpcSettingsSection({
+  networkValue,
+  customRpcValue,
+  onNetworkClick,
+  onCustomRpcClick,
+}: CustomRpcSettingsSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <SettingRow
+        label="Custom RPC"
+        value={customRpcValue}
+        onClick={onCustomRpcClick}
+      />
+      <SettingRow
+        label="Network"
+        value={networkValue}
+        valueColor="text-teal-500"
+        onClick={onNetworkClick}
+      />
+    </div>
+  );
+}

--- a/ui/popup/settings/SettingRow.stories.tsx
+++ b/ui/popup/settings/SettingRow.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import SettingRow from "./SettingRow";
+
+const meta: Meta<typeof SettingRow> = {
+  title: "Popup/Settings/Components/SettingRow",
+  component: SettingRow,
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] bg-icy-blue-950 p-4 font-sans">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onClick: { action: "click" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingRow>;
+
+export const Default: Story = {
+  args: {
+    label: "Custom RPC",
+    value: "Default",
+  },
+};
+
+export const ActiveValue: Story = {
+  args: {
+    label: "Network",
+    value: "Mainnet",
+    valueColor: "text-teal-500",
+  },
+};
+
+export const WithChevron: Story = {
+  args: {
+    label: "Change Password",
+    showChevron: true,
+  },
+};

--- a/ui/popup/settings/SettingRow.tsx
+++ b/ui/popup/settings/SettingRow.tsx
@@ -1,0 +1,32 @@
+export interface SettingRowProps {
+  label: string;
+  value?: string;
+  /** Override the value text color (e.g. teal-500 for an active network). Defaults to white. */
+  valueColor?: string;
+  showChevron?: boolean;
+  onClick?: () => void;
+}
+
+export default function SettingRow({
+  label,
+  value,
+  valueColor = "text-white",
+  showChevron = false,
+  onClick,
+}: SettingRowProps) {
+  return (
+    <button
+      type="button"
+      className="flex h-[62px] w-full items-center justify-between rounded-xl border border-daintree-700 bg-white/10 px-5"
+      onClick={onClick}
+    >
+      <span className="text-sm font-semibold text-white">{label}</span>
+      <div className="flex items-center gap-2">
+        {value && (
+          <span className={`text-sm font-semibold ${valueColor}`}>{value}</span>
+        )}
+        {showChevron && <i className="hn hn-angle-right text-xl text-daintree-400" />}
+      </div>
+    </button>
+  );
+}

--- a/ui/popup/settings/SettingRow.tsx
+++ b/ui/popup/settings/SettingRow.tsx
@@ -20,12 +20,14 @@ export default function SettingRow({
       className="flex h-[62px] w-full items-center justify-between rounded-xl border border-daintree-700 bg-white/10 px-5"
       onClick={onClick}
     >
-      <span className="text-sm font-semibold text-white">{label}</span>
-      <div className="flex items-center gap-2">
+      <span className="shrink-0 text-sm font-semibold text-white">{label}</span>
+      <div className="ml-4 flex min-w-0 items-center justify-end gap-2">
         {value && (
-          <span className={`text-sm font-semibold ${valueColor}`}>{value}</span>
+          <span className={`truncate text-sm font-semibold ${valueColor}`}>{value}</span>
         )}
-        {showChevron && <i className="hn hn-angle-right text-xl text-daintree-400" />}
+        {showChevron && (
+          <i className="hn hn-angle-right shrink-0 text-xl text-daintree-400" />
+        )}
       </div>
     </button>
   );

--- a/ui/popup/settings/SettingRow.tsx
+++ b/ui/popup/settings/SettingRow.tsx
@@ -23,7 +23,9 @@ export default function SettingRow({
       <span className="shrink-0 text-sm font-semibold text-white">{label}</span>
       <div className="ml-4 flex min-w-0 items-center justify-end gap-2">
         {value && (
-          <span className={`truncate text-sm font-semibold ${valueColor}`}>{value}</span>
+          <span className={`truncate text-sm font-semibold ${valueColor}`}>
+            {value}
+          </span>
         )}
         {showChevron && (
           <i className="hn hn-angle-right shrink-0 text-xl text-daintree-400" />


### PR DESCRIPTION
## What changed

Popup UI for the Custom RPC node feature — settings entry, node list with select/delete, and add-node flow.

**`ui/general/` (new shared components)**
- `Button` — variant (primary/secondary) × size (md 46px / lg 62px), disabled + loading states
- `ActionSheet` — generic bottom-sheet overlay shell
- `SegmentedControl` — generic pill tab switcher (e.g. Mainnet/Testnet)
- `PageHeader` — extended with an optional right-side action icon (e.g. edit pencil)

**`ui/popup/custom-rpc/`**
- `CustomRpcPage` — node list screen: network tabs, node rows, edit mode (delete, default node excluded), opens the add-node sheet
- `NodeListItem` — node row (icon, name, Default tag, url, select/remove)
- `AddCustomNodeForm` — add-node form (Node Name + RPC URL, error/loading states) rendered inside `ActionSheet`

**`ui/popup/settings/`**
- `CustomRpcSettingsSection` — Network + Custom RPC rows (for the existing Settings screen, not yet rebuilt in `ui/`)
- `SettingRow` — generic settings row (label · value · chevron)

**Fix:** `icy-blue-200` was truncated to 5 hex digits in `tailwind.config.js` (`#a2f5f`, invalid) — corrected to `#a2f5ff` per Figma, and `Button`'s loading spinner now uses the token instead of a raw hex.

## Design reference
Figma: Kastle Extension → Setting page → "custom rpc" section (node `12703:143874`).

## Storybook
All states covered — `Popup/CustomRpc/{Components,Screens}`, `Popup/Settings/Components`, `General/{Button,ActionSheet,SegmentedControl,PageHeader}`. Run `npm run storybook`.

## Notes for Dev
- Pure UI only — no data/routing wiring yet (Custom RPC node list/selection/network switching all take props; DataFlow integration is a separate step).
- PR is on the large side (component-first build for a new feature area) but is one cohesive unit — happy to split into smaller PRs if you'd prefer smaller review chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced custom RPC UI for managing mainnet/testnet nodes, including selecting, editing, removing, and adding custom nodes.
  * Added new reusable UI components: ActionSheet, Button (with loading/disabled states), SegmentedControl, and Settings row; enhanced Page Header with configurable right-side action.
  * Added Storybook coverage for the new and updated components, including interactive scenarios.
* **Bug Fixes**
  * Corrected the `icy-blue` Tailwind palette value to restore consistent color rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->