### PR TITLE
ci: add build + e2e gate on PRs, pin node 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,16 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -18,7 +23,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Prettier
         run: npm run prettier
@@ -33,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -40,7 +47,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build
@@ -50,6 +57,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -57,7 +66,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build extension
         run: npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,13 @@
-name: Lint code
+name: CI
 
 on:
   pull_request:
     branches: main
+  push:
+    branches: main
 
 jobs:
-  submit:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,3 +28,43 @@ jobs:
 
       - name: Compile
         run: npm run compile
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # ponytail: fixtures launch headed Chrome (MV3 extension), xvfb provides the display
+      - name: Run e2e tests
+        run: xvfb-run npm run e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,9 @@
         "typescript-eslint": "^8.19.1",
         "vite-plugin-node-polyfills": "^0.22.0",
         "wxt": "^0.19.24"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@1natsu/wait-element": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "version": "2.59.0",
   "type": "module",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",

--- a/tests/onboarding.spec.ts
+++ b/tests/onboarding.spec.ts
@@ -10,7 +10,7 @@ test("can reach password setup", async ({ page, extensionId }) => {
   await onboarding.navigate();
   await onboarding.pass();
 
-  const setupPassword = await SetupPasswordScreen(page, extensionId);
+  const setupPassword = await SetupPasswordScreen(page);
 
   expect(await setupPassword.navigate()).toBeDefined();
 });

--- a/tests/pages/setup-password.ts
+++ b/tests/pages/setup-password.ts
@@ -1,10 +1,9 @@
 import { Page } from "@playwright/test";
 
-export async function SetupPasswordScreen(page: Page, extensionId: string) {
+export async function SetupPasswordScreen(page: Page) {
   return {
     navigate: async () => {
-      await page.goto(`chrome-extension://${extensionId}/popup.html#/setup`);
-
+      // ponytail: password setup is now an in-place onboarding step, no own route
       return await page.waitForSelector("#setup-password-screen");
     },
   };

--- a/ui/full-page/create-password/CreatePasswordPage.tsx
+++ b/ui/full-page/create-password/CreatePasswordPage.tsx
@@ -69,7 +69,10 @@ export default function CreatePasswordPage({
   };
 
   return (
-    <div className="flex w-full items-center justify-center bg-icy-blue-900">
+    <div
+      id="setup-password-screen"
+      className="flex w-full items-center justify-center bg-icy-blue-900"
+    >
       <div className="flex h-[752px] w-[624px] flex-col justify-between overflow-clip rounded-3xl bg-icy-blue-950">
         <div className="flex flex-col gap-4">
           <PageHeader

--- a/ui/full-page/welcome/WelcomePage.tsx
+++ b/ui/full-page/welcome/WelcomePage.tsx
@@ -19,7 +19,10 @@ export default function WelcomePage({
   onSecondaryClick,
 }: WelcomePageProps) {
   return (
-    <div className="flex w-full items-center justify-center bg-icy-blue-900">
+    <div
+      id="onboarding"
+      className="flex w-full items-center justify-center bg-icy-blue-900"
+    >
       <div className="flex h-[752px] w-[624px] flex-col items-center justify-between rounded-3xl bg-icy-blue-950 pt-16">
         <div className="flex w-full flex-col items-center gap-10">
           <img alt="Kastle" className="h-5 w-[111px]" src={kastleBanner} />
@@ -41,6 +44,7 @@ export default function WelcomePage({
         </div>
         <div className="flex w-full flex-col gap-3 px-10 py-6">
           <button
+            id="pass-onboarding"
             className="flex w-full items-center justify-center rounded-full bg-icy-blue-400 px-5 py-[22px] text-[15px] font-semibold tracking-[0.075px] text-white"
             onClick={onPrimaryClick}
           >


### PR DESCRIPTION
## What

- **`lint.yml` → `CI` workflow** with three jobs, triggered on `pull_request` → main **and** `push` → main:
  - `lint` (renamed from `submit`): prettier + eslint + tsc, unchanged steps
  - `build` (new): `npm run build` — real WXT production build, catches build breaks a typecheck misses
  - `e2e` (new): builds the extension, `npx playwright install --with-deps chromium`, then `xvfb-run npm run e2e` — the fixtures launch headed Chrome with the MV3 extension loaded, so xvfb provides the display
- **`package.json`**: `engines.node: 20.x` so local and CI agree

## e2e status: wired in AND green ✅

The test had never run anywhere, and it had rotted: onboarding was rebuilt as a step-based wizard, so `#onboarding` / `#pass-onboarding` / `#setup-password-screen` no longer existed and the `#/setup` route was gone. Fixed in this PR (12 lines): restored the three ids on `WelcomePage` / `CreatePasswordPage`, and `SetupPasswordScreen` no longer navigates to the removed route. Passes locally (~6s) and in CI.

## Branch protection (Leo, run after merge)

```sh
gh api -X PUT repos/forbole/kastle/branches/main/protection \
  -f 'required_status_checks[strict]=true' \
  -f 'required_status_checks[checks][][context]=lint' \
  -f 'required_status_checks[checks][][context]=build' \
  -f 'required_status_checks[checks][][context]=e2e' \
  -F 'enforce_admins=false' \
  -F 'required_pull_request_reviews=null' \
  -F 'restrictions=null'
```

e2e ran green on first fixed attempt; if it ever turns flaky, drop its line from the command above and re-run — lint + build stay the hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding flow validation, including welcome and password setup screens.
  * Updated password setup navigation to work correctly within the onboarding experience.

* **Tests**
  * Expanded automated checks to cover linting, builds, and end-to-end onboarding scenarios.

* **Chores**
  * Continuous integration now runs for pull requests and pushes to the main branch.
  * Standardized supported runtime to Node.js 20.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->