### PR TITLE
chore: ignore local agent and tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ web-ext.config.ts
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Local agent/tooling state
+.claude/
+.serena/
+graphify-out/
+handover-output/


### PR DESCRIPTION
Adds four per-developer tooling directories to `.gitignore`:

```
.claude/
.serena/
graphify-out/
handover-output/
```

## Nothing needed removing

Checked before writing the rule — none of these are tracked on `main`, and none appear anywhere in `main`'s history. This is preventative, not a cleanup.

## One thing this does *not* fix

`.claude/launch.json` **is** tracked on the remote branch `feat/custom-rpc-ui` (commit `83e1c17`). A `.gitignore` rule has no effect on an already-tracked file, so if that branch merges, the file lands on `main` regardless. It needs a `git rm --cached .claude/launch.json` on that branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)