### PR TITLE
fix: allow script-free dApp signing on Ledger; refuse sign-only requests upfront with an accurate reason

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -3,15 +3,15 @@
 Admin-only command surface for the support bot. All commands require the caller
 to be listed as an admin; unauthorised callers get a refusal.
 
-| Command | Description |
-| --- | --- |
-| `/help_admin` | Show the admin command list. |
-| `/ping` | Health check with uptime. |
-| `/stats` | Display metrics counters and latency averages. |
-| `/mode` | Show current configuration. |
-| `/set_threshold <0..1>` | Adjust in-memory confidence threshold until restart. |
-| `/stop [duration]` | Pause bot for `10s`, `5m`, `2h`, `1d`, or default duration. Use `0`/`cancel` to resume immediately. |
-| `/resume` | Resume the bot immediately. |
-| `/teach [override\|append] <answer>` | Reply to a user's question with this command to store an override. |
-| `/teach_list` | List the overrides (teachings) currently stored. |
-| `/teach_delete <id or pattern>` | Remove stored overrides by id or pattern snippet. Pattern snippets must be at least 4 characters. |
+| Command                              | Description                                                                                         |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `/help_admin`                        | Show the admin command list.                                                                        |
+| `/ping`                              | Health check with uptime.                                                                           |
+| `/stats`                             | Display metrics counters and latency averages.                                                      |
+| `/mode`                              | Show current configuration.                                                                         |
+| `/set_threshold <0..1>`              | Adjust in-memory confidence threshold until restart.                                                |
+| `/stop [duration]`                   | Pause bot for `10s`, `5m`, `2h`, `1d`, or default duration. Use `0`/`cancel` to resume immediately. |
+| `/resume`                            | Resume the bot immediately.                                                                         |
+| `/teach [override\|append] <answer>` | Reply to a user's question with this command to store an override.                                  |
+| `/teach_list`                        | List the overrides (teachings) currently stored.                                                    |
+| `/teach_delete <id or pattern>`      | Remove stored overrides by id or pattern snippet. Pattern snippets must be at least 4 characters.   |

--- a/components/screens/browser-api/kaspa/LedgerNotSupported.tsx
+++ b/components/screens/browser-api/kaspa/LedgerNotSupported.tsx
@@ -8,7 +8,7 @@ type LedgerNotSupportedProps = {
 };
 
 export default function LedgerNotSupported({
-  subtitle = "Advanced Script Transaction are not supported on Ledger.",
+  subtitle = "Advanced Script Transactions are not supported on Ledger.",
   detail = "Ledger currently does not support Advanced Script Transactions (e.g. KRC20). To proceed, please switch to a non-Ledger account.",
 }: LedgerNotSupportedProps) {
   const onClose = () => {

--- a/components/screens/browser-api/kaspa/LedgerNotSupported.tsx
+++ b/components/screens/browser-api/kaspa/LedgerNotSupported.tsx
@@ -2,7 +2,15 @@ import React from "react";
 import alertImage from "@/assets/images/alert.png";
 import Header from "@/components/GeneralHeader";
 
-export default function LedgerNotSupported() {
+type LedgerNotSupportedProps = {
+  subtitle?: string;
+  detail?: string;
+};
+
+export default function LedgerNotSupported({
+  subtitle = "Advanced Script Transaction are not supported on Ledger.",
+  detail = "Ledger currently does not support Advanced Script Transactions (e.g. KRC20). To proceed, please switch to a non-Ledger account.",
+}: LedgerNotSupportedProps) {
   const onClose = () => {
     window.close();
   };
@@ -22,14 +30,8 @@ export default function LedgerNotSupported() {
             <span className="text-xl font-semibold text-red-500">
               Sorry, Your Majesty.
             </span>
-            <span className="px-2 text-sm text-gray-500">
-              {"Advanced Script Transaction are not supported on Ledger."}
-            </span>
-            <div className="rounded bg-[#203C49] p-2 text-sm">
-              {
-                "Ledger currently does not support Advanced Script Transactions (e.g. KRC20). To proceed, please switch to a non-Ledger account."
-              }
-            </div>
+            <span className="px-2 text-sm text-gray-500">{subtitle}</span>
+            <div className="rounded bg-[#203C49] p-2 text-sm">{detail}</div>
           </div>
         </div>
 

--- a/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
+++ b/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
@@ -6,6 +6,7 @@ import { ApiExtensionUtils } from "@/api/extension";
 import { ApiUtils } from "@/api/background/utils";
 import LedgerConnectForSign from "@/components/screens/ledger-connect/LedgerConnectForSign";
 import useKaspaLedgerSigner from "@/hooks/wallet/useKaspaLedgerSigner";
+import { hasScriptOptions } from "@/lib/wallet/sign-script.ts";
 
 type LedgerSignAndBroadcastProps = {
   requestId: string;
@@ -21,7 +22,7 @@ export default function LedgerSignAndBroadcast({
   const { transport, isAppOpen } = useLedgerTransport();
   const walletSigner = useKaspaLedgerSigner();
 
-  if (payload.scripts?.length) {
+  if (hasScriptOptions(payload.scripts)) {
     ApiExtensionUtils.sendMessage(
       requestId,
       ApiUtils.createApiResponse(

--- a/components/screens/browser-api/kaspa/sign-and-broadcast/SignAndBroadcast.tsx
+++ b/components/screens/browser-api/kaspa/sign-and-broadcast/SignAndBroadcast.tsx
@@ -13,7 +13,10 @@ import {
   TransactionOutput,
 } from "@/wasm/core/kaspa";
 import { calcRevealInputMass } from "@/lib/kaspaFee";
-import { hasPartialOutputCommitment } from "@/lib/wallet/sign-script.ts";
+import {
+  hasPartialOutputCommitment,
+  hasScriptOptions,
+} from "@/lib/wallet/sign-script.ts";
 import { PARTIAL_OUTPUT_WARNING } from "@/components/screens/browser-api/kaspa/sign-tx/SignTx";
 
 type SignAndBroadcastProps = {
@@ -94,7 +97,12 @@ export default function SignAndBroadcast({
     }
 
     try {
-      const signedTx = await wallet.signTx(transaction, payload.scripts);
+      // The Ledger signer refuses any truthy `scripts` value, so the schema's
+      // empty default must reach it as undefined (script-free signing).
+      const signedTx = await wallet.signTx(
+        transaction,
+        hasScriptOptions(payload.scripts) ? payload.scripts : undefined,
+      );
 
       const MAX_RETRIES = 5;
       let txId: string | undefined;

--- a/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
+++ b/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
@@ -28,10 +28,18 @@ export default function LedgerSignTx({
     ? "Ledger does not support advanced scripts signing"
     : "Ledger cannot complete sign-only requests yet. Use a dApp flow that signs and broadcasts.";
 
-  ApiExtensionUtils.sendMessage(
-    requestId,
-    ApiUtils.createApiResponse(requestId, null, message),
-  );
+  // Dispatch outside the render phase and once per mount: React can render
+  // this component more than once, and each requestId must produce exactly
+  // one rejection response.
+  const sentRef = useRef(false);
+  useEffect(() => {
+    if (sentRef.current) return;
+    sentRef.current = true;
+    ApiExtensionUtils.sendMessage(
+      requestId,
+      ApiUtils.createApiResponse(requestId, null, message),
+    );
+  }, [requestId, message]);
 
   return scripted ? (
     <LedgerNotSupported />

--- a/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
+++ b/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
@@ -1,12 +1,7 @@
 import { SignTxPayload } from "@/api/background/handlers/kaspa/utils";
 import LedgerNotSupported from "@/components/screens/browser-api/kaspa/LedgerNotSupported";
-import SignTx from "@/components/screens/browser-api/kaspa/sign-tx/SignTx";
-import Splash from "@/components/screens/Splash";
 import { ApiExtensionUtils } from "@/api/extension";
-import LedgerConnectForSign from "@/components/screens/ledger-connect/LedgerConnectForSign";
 import { ApiUtils } from "@/api/background/utils";
-import useKaspaLedgerSigner from "@/hooks/wallet/useKaspaLedgerSigner";
-import useLedgerTransport from "@/hooks/useLedgerTransport";
 import { hasScriptOptions } from "@/lib/wallet/sign-script.ts";
 
 type LedgerSignTxProps = {
@@ -15,42 +10,35 @@ type LedgerSignTxProps = {
   origin: string;
 };
 
+// Sign-only requests are refused on Ledger even when they carry no scripts:
+// the signed transaction rebuilt by the Ledger account's toRpcTransaction has
+// no UTXO entries, so returning it to the dApp fails safe-serialization AFTER
+// the user has already signed on-device (device QA 2026-08-25) — a wasted
+// hardware signature is worse than an upfront refusal. Unblock: KAS-002 items
+// 2 and 3 (toRpcTransaction UTXO entries / derivation metadata).
+// signAndBroadcastTx is unaffected: it submits via RPC without
+// safe-serializing, and is device-verified end-to-end.
 export default function LedgerSignTx({
   requestId,
   payload,
-  origin,
 }: LedgerSignTxProps) {
-  const { transport, isAppOpen } = useLedgerTransport();
-  const walletSigner = useKaspaLedgerSigner();
+  // Keep the two refusals distinct so the dApp is told the true reason.
+  const scripted = hasScriptOptions(payload.scripts);
+  const message = scripted
+    ? "Ledger does not support advanced scripts signing"
+    : "Ledger cannot complete sign-only requests yet. Use a dApp flow that signs and broadcasts.";
 
-  // scripts defaults to [] in the payload schema, so gate on actual script
-  // options — a bare truthy check would refuse every Ledger request.
-  if (hasScriptOptions(payload.scripts)) {
-    ApiExtensionUtils.sendMessage(
-      requestId,
-      ApiUtils.createApiResponse(
-        requestId,
-        null,
-        "Ledger does not support advanced scripts signing",
-      ),
-    );
-    return <LedgerNotSupported />;
-  }
+  ApiExtensionUtils.sendMessage(
+    requestId,
+    ApiUtils.createApiResponse(requestId, null, message),
+  );
 
-  return (
-    <>
-      {(!transport || !isAppOpen) && (
-        <LedgerConnectForSign showClose={false} showPrevious={false} />
-      )}
-      {transport && isAppOpen && !walletSigner && <Splash />}
-      {walletSigner && isAppOpen && (
-        <SignTx
-          wallet={walletSigner}
-          requestId={requestId}
-          payload={payload}
-          origin={origin}
-        />
-      )}
-    </>
+  return scripted ? (
+    <LedgerNotSupported />
+  ) : (
+    <LedgerNotSupported
+      subtitle="Sign-only requests are not supported on Ledger yet."
+      detail="Ledger cannot complete sign-only requests yet. Use a dApp flow that signs and broadcasts, or switch to a non-Ledger account."
+    />
   );
 }

--- a/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
+++ b/components/screens/browser-api/kaspa/sign-tx/LedgerSignTx.tsx
@@ -7,6 +7,7 @@ import LedgerConnectForSign from "@/components/screens/ledger-connect/LedgerConn
 import { ApiUtils } from "@/api/background/utils";
 import useKaspaLedgerSigner from "@/hooks/wallet/useKaspaLedgerSigner";
 import useLedgerTransport from "@/hooks/useLedgerTransport";
+import { hasScriptOptions } from "@/lib/wallet/sign-script.ts";
 
 type LedgerSignTxProps = {
   requestId: string;
@@ -22,7 +23,9 @@ export default function LedgerSignTx({
   const { transport, isAppOpen } = useLedgerTransport();
   const walletSigner = useKaspaLedgerSigner();
 
-  if (payload.scripts) {
+  // scripts defaults to [] in the payload schema, so gate on actual script
+  // options — a bare truthy check would refuse every Ledger request.
+  if (hasScriptOptions(payload.scripts)) {
     ApiExtensionUtils.sendMessage(
       requestId,
       ApiUtils.createApiResponse(

--- a/components/screens/browser-api/kaspa/sign-tx/SignTx.tsx
+++ b/components/screens/browser-api/kaspa/sign-tx/SignTx.tsx
@@ -6,7 +6,10 @@ import SignConfirm from "@/components/screens/browser-api/kaspa/sign/SignConfirm
 import { ApiUtils } from "@/api/background/utils";
 import useAnalytics from "@/hooks/useAnalytics";
 import { deserializeTransaction } from "@/lib/kaspa-compat";
-import { hasPartialOutputCommitment } from "@/lib/wallet/sign-script.ts";
+import {
+  hasPartialOutputCommitment,
+  hasScriptOptions,
+} from "@/lib/wallet/sign-script.ts";
 
 export const PARTIAL_OUTPUT_WARNING =
   "This request signs with a sighash type that commits to only part of the transaction outputs. The outputs it does not cover are not protected by your signature and can still be changed after you approve.";
@@ -34,7 +37,12 @@ export default function SignTx({
 
     try {
       const tx = deserializeTransaction(payload.txJson);
-      const signed = await wallet.signTx(tx, payload.scripts);
+      // The Ledger signer refuses any truthy `scripts` value, so the schema's
+      // empty default must reach it as undefined (script-free signing).
+      const signed = await wallet.signTx(
+        tx,
+        hasScriptOptions(payload.scripts) ? payload.scripts : undefined,
+      );
       await ApiExtensionUtils.sendMessage(
         requestId,
         ApiUtils.createApiResponse(requestId, signed.serializeToSafeJSON()),

--- a/components/screens/browser-api/kaspa/sign/DetailsSelector.tsx
+++ b/components/screens/browser-api/kaspa/sign/DetailsSelector.tsx
@@ -45,7 +45,7 @@ export default function DetailsSelector({
 
       {/* Scripts */}
       <div className="space-y-3">
-        {activeTab === "scripts" && !payload.scripts && (
+        {activeTab === "scripts" && !payload.scripts?.length && (
           <div className="flex h-20 w-full items-center justify-center rounded-lg bg-[#102832] text-center text-[#7B9AAA]">
             No scripts for this transaction
           </div>

--- a/lib/wallet/sign-script.ts
+++ b/lib/wallet/sign-script.ts
@@ -58,6 +58,18 @@ export function hasPartialOutputCommitment(
   );
 }
 
+/**
+ * True when the request carries at least one actual script option. The dApp
+ * payload schema defaults `scripts` to [], so callers must not use a bare
+ * existence check — an empty (or all-null sparse) array means "no scripts".
+ * Non-throwing: safe to call from render paths.
+ */
+export function hasScriptOptions(
+  scripts?: (RawScriptOption | null | undefined)[],
+): boolean {
+  return (scripts ?? []).some((option) => option != null);
+}
+
 export function normalizeScriptOptions(
   scripts?: (RawScriptOption | null | undefined)[],
 ): ScriptOption[] {

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -715,9 +715,14 @@ test.describe("ledger signer index parity (F7)", () => {
   });
 });
 
-// L1: the payload schema defaults `scripts` to [], so the Ledger screens must
-// gate on actual script options. A bare existence check is always truthy and
-// refused every dApp signTx routed to a Ledger account (the v2.59.1 outage).
+// L1: the payload schema defaults `scripts` to [], so consumers must gate on
+// actual script options — a bare existence check is always truthy and refused
+// every dApp signTx routed to a Ledger account (the v2.59.1 outage).
+// hasScriptOptions drives: the LedgerSignAndBroadcast gate, the
+// wallet.signTx call-site normalization ([] -> undefined) in both confirm
+// screens, and the refusal-message selection in LedgerSignTx (sign-only is
+// always refused on Ledger until KAS-002 items 2 and 3, but script-bearing
+// and script-free requests must get different reasons).
 test.describe("ledger script gate (L1)", () => {
   test("empty scripts array is not a script-bearing request", () => {
     expect(hasScriptOptions([])).toBe(false);

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -14,6 +14,7 @@ import init, {
 import { deserializeTransaction } from "@/lib/kaspa-compat";
 import {
   hasPartialOutputCommitment,
+  hasScriptOptions,
   normalizeScriptOptions,
   pushDataHex,
   signTxInputWithScriptOption,
@@ -21,6 +22,7 @@ import {
   type RawScriptOption,
 } from "@/lib/wallet/sign-script";
 import { SIGN_TYPE, toSignType } from "@/lib/kaspa";
+import { SignTxPayloadSchema } from "@/api/background/handlers/kaspa/utils";
 import type { SignType } from "@/lib/wallet/wallet-interface";
 
 // Throwaway key — unit tests only, never funded.
@@ -710,5 +712,37 @@ test.describe("ledger signer index parity (F7)", () => {
     for (const args of calls) {
       expect(args).toEqual(["transport", "accountIndex"]);
     }
+  });
+});
+
+// L1: the payload schema defaults `scripts` to [], so the Ledger screens must
+// gate on actual script options. A bare existence check is always truthy and
+// refused every dApp signTx routed to a Ledger account (the v2.59.1 outage).
+test.describe("ledger script gate (L1)", () => {
+  test("empty scripts array is not a script-bearing request", () => {
+    expect(hasScriptOptions([])).toBe(false);
+  });
+
+  test("absent scripts gets the schema default and is not refused", () => {
+    const parsed = SignTxPayloadSchema.parse({ txJson: "{}" });
+    expect(parsed.scripts).toEqual([]);
+    expect(hasScriptOptions(parsed.scripts)).toBe(false);
+  });
+
+  test("script-bearing requests still trip the gate", () => {
+    expect(hasScriptOptions([{ inputIndex: 0, scriptHex: "aabb" }])).toBe(true);
+    const parsed = SignTxPayloadSchema.parse({
+      txJson: "{}",
+      scripts: [{ inputIndex: 0, scriptHex: "aabb" }],
+    });
+    expect(hasScriptOptions(parsed.scripts)).toBe(true);
+  });
+
+  test("sparse arrays count only real options", () => {
+    expect(hasScriptOptions([null, undefined] as any)).toBe(false);
+    expect(hasScriptOptions(undefined)).toBe(false);
+    expect(
+      hasScriptOptions([null, { inputIndex: 1, scriptHex: "aabb" }] as any),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

v2.59.1 refuses EVERY dApp `signTx`/`signAndBroadcastTx` routed to a Ledger account — including ordinary script-free transactions — with "Ledger does not support advanced scripts signing". All dApp signing on Ledger is dead. Fails closed (error, never a bad signature): product outage, not a security issue. Pre-existing; not caused by #306.

## Root cause

`SignTxPayloadSchema` defaults `scripts` to `[]` (`api/background/handlers/kaspa/utils.ts:7`), so `payload.scripts` is ALWAYS an array — and `[]` is truthy:

1. `LedgerSignTx.tsx` gated on bare `if (payload.scripts)` → always refused.
2. Both confirm screens passed the truthy `[]` into `wallet.signTx`, tripping the Ledger account's `if (scripts) throw new Error("Method not implemented.")` (`ledger-account.ts:57`) — which is why `LedgerSignAndBroadcast` was broken at confirm time despite already having a correct `?.length` gate.

## Changes

- **`lib/wallet/sign-script.ts`**: new `hasScriptOptions()` — true only when at least one non-null script option exists (matches `normalizeScriptOptions` sparse-array semantics).
- **`LedgerSignAndBroadcast.tsx`**: gate on `hasScriptOptions(payload.scripts)`; script-bearing requests still refused with the existing message.
- **`SignTx.tsx` / `SignAndBroadcast.tsx`**: pass `undefined` instead of the empty default to `wallet.signTx` so the Ledger guard isn't tripped; hot-wallet behavior identical (`normalize(undefined) ≡ normalize([])`).
- **`LedgerSignTx.tsx` (sign-only)**: refused upfront regardless of scripts — device QA showed the sign-only path fails AFTER on-device signing (`toRpcTransaction` drops UTXO entries → `serializeToSafeJSON` throws "Transaction input is missing UTXO entry"), and a wasted hardware signature is worse than a clean refusal. `hasScriptOptions` selects the accurate message: script-bearing keeps the advanced-scripts refusal; script-free gets "Ledger cannot complete sign-only requests yet. Use a dApp flow that signs and broadcasts." Unblock: KAS-002 items 2 and 3.
- **`LedgerNotSupported.tsx`**: optional `subtitle`/`detail` props (defaults unchanged) so the sign-only refusal screen shows the true reason.
- **`DetailsSelector.tsx`**: `!payload.scripts` never fired — "No scripts for this transaction" empty state now renders.
- **`tests/signtx-unit.spec.ts`**: `ledger script gate (L1)` block — `[]`, schema-defaulted absent, script-bearing, and sparse-array cases.

NOT changed: the zod `.default([])` (would ripple through every consumer) and `lib/wallet/account/ledger-account.ts` (0-byte diff — KAS-002 scope).

## Verification

- tsc, eslint (baseline-identical), prettier: clean
- `signtx-unit.spec.ts`: 20/20 · full e2e: 21 passed, 0 failed
- `package.json`/`package-lock.json`: no diff
- #306 sighash work untouched (`assertSafeOutputSighash`, `ALLOW_UNSAFE_OUTPUT_SIGHASH`, `toSignType` guard, `PARTIAL_OUTPUT_WARNING` wiring)
- **Device QA on testnet-10 (Nano + Kaspa app)**: `signAndBroadcastTx` with `scripts: []` on Ledger — gate passed → device prompt → signed → broadcast accepted, txId returned. Script-bearing request still refused. Sign-only refused upfront with the new message, no device prompt. #306 `None`/`Single` behavior intact on hot wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ledger signing behavior for transactions without script options.
  * Ledger now clearly explains when sign-only requests or advanced script signing are unsupported.
  * Prevented empty script data from being incorrectly treated as active script options.
  * Updated script details to show an accurate empty state when no scripts are configured.

* **Improvements**
  * Added more flexible messaging for Ledger unsupported-operation notices.
  * Improved consistency across transaction signing and sign-and-broadcast flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->