### PR TITLE
fix: refuse Ledger transactions carrying fields the device cannot sign over

### DIFF
--- a/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
+++ b/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
@@ -18,6 +18,12 @@ type LedgerSignAndBroadcastProps = {
   origin: string;
 };
 
+// Approved refusal copy for unsignable-field requests (A1 addendum). ONE
+// constant feeds BOTH the dApp rejection and the on-screen detail so the two
+// reasons can never drift apart.
+export const LEDGER_UNSIGNABLE_FIELDS_MESSAGE =
+  "Ledger can't verify this transaction's memo, time lock, or other advanced fields yet. Try a hot wallet account instead.";
+
 export default function LedgerSignAndBroadcast({
   requestId,
   payload,
@@ -48,7 +54,7 @@ export default function LedgerSignAndBroadcast({
   const refusalMessage = scripted
     ? "Ledger does not support advanced scripts signing"
     : unsignable
-      ? "This transaction uses features your Ledger cannot verify (time locks, sequence numbers, or payload data)."
+      ? LEDGER_UNSIGNABLE_FIELDS_MESSAGE
       : undefined;
 
   // Dispatch outside the render phase and once per mount: React can render
@@ -72,7 +78,7 @@ export default function LedgerSignAndBroadcast({
     return (
       <LedgerNotSupported
         subtitle="This transaction can't be verified on your Ledger."
-        detail="This transaction uses features your Ledger cannot verify (time locks, sequence numbers, or payload data). To proceed, please switch to a non-Ledger account."
+        detail={LEDGER_UNSIGNABLE_FIELDS_MESSAGE}
       />
     );
   }

--- a/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
+++ b/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
@@ -6,7 +6,11 @@ import { ApiExtensionUtils } from "@/api/extension";
 import { ApiUtils } from "@/api/background/utils";
 import LedgerConnectForSign from "@/components/screens/ledger-connect/LedgerConnectForSign";
 import useKaspaLedgerSigner from "@/hooks/wallet/useKaspaLedgerSigner";
-import { hasScriptOptions } from "@/lib/wallet/sign-script.ts";
+import {
+  hasScriptOptions,
+  hasUnsignableFields,
+} from "@/lib/wallet/sign-script.ts";
+import { deserializeTransaction } from "@/lib/kaspa-compat";
 
 type LedgerSignAndBroadcastProps = {
   requestId: string;
@@ -22,16 +26,55 @@ export default function LedgerSignAndBroadcast({
   const { transport, isAppOpen } = useLedgerTransport();
   const walletSigner = useKaspaLedgerSigner();
 
-  if (hasScriptOptions(payload.scripts)) {
+  const scripted = hasScriptOptions(payload.scripts);
+
+  // KAS-002 defect A1: the Ledger app signs over zeroed lockTime / input
+  // sequence / gas / subnetworkId / payload (and forces SIGHASH_ALL) no
+  // matter what the transaction carries — hw-app-kaspa never sends those
+  // fields over the wire. A request using any of them would still get a
+  // VALID signature, but over the zeroed rewrite: the user approves one
+  // transaction and a different one broadcasts. Refuse BEFORE any device
+  // interaction. A txJson that cannot be deserialized cannot be proven
+  // safe, so it is refused the same way. Unblock: KAS-002 A2 (Ledger
+  // app/firmware support for these fields).
+  const unsignable = useMemo(() => {
+    try {
+      return hasUnsignableFields(deserializeTransaction(payload.txJson));
+    } catch {
+      return true;
+    }
+  }, [payload.txJson]);
+
+  const refusalMessage = scripted
+    ? "Ledger does not support advanced scripts signing"
+    : unsignable
+      ? "This transaction uses features your Ledger cannot verify (time locks, sequence numbers, or payload data)."
+      : undefined;
+
+  // Dispatch outside the render phase and once per mount: React can render
+  // this component more than once, and each requestId must produce exactly
+  // one rejection response.
+  const sentRef = useRef(false);
+  useEffect(() => {
+    if (!refusalMessage || sentRef.current) return;
+    sentRef.current = true;
     ApiExtensionUtils.sendMessage(
       requestId,
-      ApiUtils.createApiResponse(
-        requestId,
-        null,
-        "Ledger does not support advanced scripts signing",
-      ),
+      ApiUtils.createApiResponse(requestId, null, refusalMessage),
     );
+  }, [requestId, refusalMessage]);
+
+  if (scripted) {
     return <LedgerNotSupported />;
+  }
+
+  if (unsignable) {
+    return (
+      <LedgerNotSupported
+        subtitle="This transaction can't be verified on your Ledger."
+        detail="This transaction uses features your Ledger cannot verify (time locks, sequence numbers, or payload data). To proceed, please switch to a non-Ledger account."
+      />
+    );
   }
 
   return (

--- a/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
+++ b/components/screens/browser-api/kaspa/sign-and-broadcast/LedgerSignAndBroadcast.tsx
@@ -57,13 +57,14 @@ export default function LedgerSignAndBroadcast({
       ? LEDGER_UNSIGNABLE_FIELDS_MESSAGE
       : undefined;
 
-  // Dispatch outside the render phase and once per mount: React can render
-  // this component more than once, and each requestId must produce exactly
-  // one rejection response.
-  const sentRef = useRef(false);
+  // Dispatch outside the render phase, exactly once per requestId: React can
+  // render this component more than once, and a still-mounted screen could in
+  // principle be handed a new requestId via query-param navigation — each
+  // requestId must produce exactly one rejection response.
+  const sentForRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!refusalMessage || sentRef.current) return;
-    sentRef.current = true;
+    if (!refusalMessage || sentForRef.current === requestId) return;
+    sentForRef.current = requestId;
     ApiExtensionUtils.sendMessage(
       requestId,
       ApiUtils.createApiResponse(requestId, null, refusalMessage),

--- a/lib/wallet/sign-script.ts
+++ b/lib/wallet/sign-script.ts
@@ -70,6 +70,56 @@ export function hasScriptOptions(
   return (scripts ?? []).some((option) => option != null);
 }
 
+// The all-zero "native" subnetwork — the only value the Ledger app can sign
+// over (and the one its sighash hardcodes). Same literal the Ledger account
+// rebuilds broadcast transactions with (lib/wallet/account/ledger-account.ts).
+const NATIVE_SUBNETWORK_ID = "00".repeat(20);
+
+// Payload values that mean "no payload". The WASM getter returns plain hex
+// ("" when empty), but be tolerant of undefined/null and a bare "0x" prefix.
+function isEmptyPayload(payload: unknown): boolean {
+  return payload == null || payload === "" || payload === "0x";
+}
+
+/**
+ * KAS-002 defect A1 — fields the Ledger device provably does not sign over.
+ *
+ * hw-app-kaspa v1.2.1 serialises each input as a fixed 46-byte frame
+ * (value / prevTxId / outpointIndex / addressType / addressIndex), so
+ * `sequence`, `lockTime`, `gas`, `subnetworkId` and `payload` never cross the
+ * APDU wire, and the Ledger app's sighash hardcodes them all to zero (and
+ * `version`, and forces SIGHASH_ALL). A transaction carrying any non-default
+ * value still produces a VALID signature — over the zeroed rewrite, not over
+ * what the user inspected — so the user approves one transaction and a
+ * different one broadcasts. Refuse before any device interaction.
+ * Unblock: KAS-002 A2 (Ledger app support for these fields).
+ *
+ * Field types and zero values per wasm/core/kaspa.d.ts (class Transaction):
+ * version: number, lockTime: bigint, gas: bigint, subnetworkId: string,
+ * payload: string, inputs[].sequence: bigint.
+ *
+ * Fail closed: malformed or ambiguous values count as unsignable.
+ * Non-throwing: safe to call from render paths.
+ */
+export function hasUnsignableFields(tx: Transaction): boolean {
+  try {
+    if (tx.version !== 0) return true;
+    if (tx.lockTime !== 0n) return true;
+    if (tx.gas !== 0n) return true;
+    if (!isEmptyPayload(tx.payload)) return true;
+    if (tx.subnetworkId !== NATIVE_SUBNETWORK_ID) return true;
+    // read tx.inputs once — each access crosses the WASM boundary
+    const inputs = tx.inputs ?? [];
+    for (const input of inputs) {
+      if (input?.sequence !== 0n) return true;
+    }
+    return false;
+  } catch {
+    // a transaction whose fields cannot even be read cannot be proven safe
+    return true;
+  }
+}
+
 export function normalizeScriptOptions(
   scripts?: (RawScriptOption | null | undefined)[],
 ): ScriptOption[] {

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -6,6 +6,8 @@ import { blake2b } from "@noble/hashes/blake2b";
 import { schnorr } from "@noble/curves/secp256k1";
 import init, {
   createInputSignature,
+  createTransactions,
+  payToAddressScript,
   PrivateKey,
   ScriptBuilder,
   SighashType,
@@ -15,6 +17,7 @@ import { deserializeTransaction } from "@/lib/kaspa-compat";
 import {
   hasPartialOutputCommitment,
   hasScriptOptions,
+  hasUnsignableFields,
   normalizeScriptOptions,
   pushDataHex,
   signTxInputWithScriptOption,
@@ -749,5 +752,134 @@ test.describe("ledger script gate (L1)", () => {
     expect(
       hasScriptOptions([null, { inputIndex: 1, scriptHex: "aabb" }] as any),
     ).toBe(true);
+  });
+});
+
+// A1: fields the Ledger device provably does not sign over. hw-app-kaspa's
+// APDU frame carries only value/prevTxId/outpointIndex/addressType/
+// addressIndex per input, and the Ledger app hardcodes version, lockTime,
+// gas, subnetworkId, payload and every input sequence to zero in its sighash
+// (and forces SIGHASH_ALL). Any non-default value still yields a VALID
+// signature — over the zeroed rewrite — so LedgerSignAndBroadcast refuses
+// these upfront via hasUnsignableFields. The React screens have no component
+// harness, so the predicate is what gets covered here. Unblock: KAS-002 A2.
+test.describe("ledger unsignable-field gate (A1)", () => {
+  const NATIVE_SUBNETWORK = "00".repeat(20);
+  const SPK = "0000" + "20" + "ab".repeat(32) + "ac";
+
+  const mkTxJson = (
+    overrides: Record<string, unknown> = {},
+    inputOverrides: Record<string, unknown> = {},
+  ) =>
+    JSON.stringify({
+      id: "00".repeat(32),
+      version: 0,
+      inputs: [
+        {
+          transactionId: "11".repeat(32),
+          index: 0,
+          sequence: "0",
+          sigOpCount: 1,
+          computeBudget: 0,
+          signatureScript: "",
+          utxo: {
+            address: null,
+            amount: "100000000",
+            scriptPublicKey: SPK,
+            blockDaaScore: "1000",
+            isCoinbase: false,
+          },
+          ...inputOverrides,
+        },
+      ],
+      outputs: [{ value: "90000000", scriptPublicKey: SPK }],
+      lockTime: "0",
+      subnetworkId: NATIVE_SUBNETWORK,
+      gas: "0",
+      payload: "",
+      ...overrides,
+    });
+
+  const txWith = (
+    overrides: Record<string, unknown> = {},
+    inputOverrides: Record<string, unknown> = {},
+  ) => Transaction.deserializeFromSafeJSON(mkTxJson(overrides, inputOverrides));
+
+  test("a fully-default transaction is signable", () => {
+    expect(hasUnsignableFields(txWith())).toBe(false);
+  });
+
+  test("every field the device zeroes trips the gate", () => {
+    expect(hasUnsignableFields(txWith({ lockTime: "5" }))).toBe(true);
+    expect(hasUnsignableFields(txWith({ gas: "1" }))).toBe(true);
+    expect(hasUnsignableFields(txWith({ payload: "beef" }))).toBe(true);
+    expect(
+      hasUnsignableFields(txWith({ subnetworkId: "01" + "00".repeat(19) })),
+    ).toBe(true);
+    expect(hasUnsignableFields(txWith({ version: 1 }))).toBe(true);
+    expect(hasUnsignableFields(txWith({}, { sequence: "1" }))).toBe(true);
+    expect(
+      hasUnsignableFields(txWith({}, { sequence: "18446744073709551615" })),
+    ).toBe(true);
+  });
+
+  test("empty payload variants are signable", () => {
+    const base = {
+      version: 0,
+      lockTime: 0n,
+      gas: 0n,
+      subnetworkId: NATIVE_SUBNETWORK,
+      inputs: [{ sequence: 0n }],
+    };
+    for (const payload of [undefined, null, "", "0x"]) {
+      expect(hasUnsignableFields({ ...base, payload } as any)).toBe(false);
+    }
+  });
+
+  test("malformed transactions do not throw and fail closed", () => {
+    const base = {
+      version: 0,
+      lockTime: 0n,
+      gas: 0n,
+      payload: "",
+      subnetworkId: NATIVE_SUBNETWORK,
+    };
+    // sparse inputs: a hole is an input whose sequence cannot be proven zero
+    expect(
+      hasUnsignableFields({ ...base, inputs: [null, undefined] } as any),
+    ).toBe(true);
+    // non-iterable inputs cannot be proven safe either
+    expect(hasUnsignableFields({ ...base, inputs: 5 } as any)).toBe(true);
+    expect(hasUnsignableFields(null as any)).toBe(true);
+    expect(hasUnsignableFields({} as any)).toBe(true);
+    // no inputs at all: nothing carries a sequence, nothing to refuse
+    expect(hasUnsignableFields({ ...base, inputs: [] } as any)).toBe(false);
+  });
+
+  // S3: the internal Send flow (ConfirmStep) builds its transaction with the
+  // WASM Generator and sets none of the guarded fields — prove the gate is a
+  // no-op for Generator output so it can never brick internal Send.
+  test("a Generator-built transaction (internal Send flow shape) passes the gate", async () => {
+    const address = new PrivateKey(TEST_KEY).toPublicKey().toAddress("mainnet");
+    const { transactions } = await createTransactions({
+      entries: [
+        {
+          address,
+          outpoint: { transactionId: "11".repeat(32), index: 0 },
+          amount: 500_000_000n,
+          scriptPublicKey: payToAddressScript(address),
+          blockDaaScore: 1_000n,
+          isCoinbase: false,
+        },
+      ],
+      outputs: [{ address, amount: 100_000_000n }],
+      priorityFee: 0n,
+      changeAddress: address,
+      networkId: "mainnet",
+    });
+    expect(transactions.length).toBeGreaterThan(0);
+    for (const pending of transactions) {
+      expect(hasUnsignableFields(pending.transaction)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Problem (KAS-002 defect A1)

`hw-app-kaspa` v1.2.1 serialises each input as a fixed 46-byte APDU frame carrying only value / prevTxId / outpointIndex / addressType / addressIndex — `sequence`, `lockTime`, `gas`, `subnetworkId` and `payload` never cross the wire — and the Ledger app's sighash hardcodes them all to zero while forcing SIGHASH_ALL. `toRpcTransaction` then rebuilds the broadcast transaction with the same zeros. Net effect: the device produces a **valid signature over a transaction the user did not approve** — anything a dApp set in those fields is silently stripped between the confirm screen (which renders the original txJson) and broadcast.

## Fix — fail closed, before any device interaction

- **`hasUnsignableFields(tx)`** in `lib/wallet/sign-script.ts` (beside `hasScriptOptions`): true when `version !== 0`, `lockTime !== 0n`, `gas !== 0n`, payload non-empty (`""`/`undefined`/`null`/`"0x"` count as empty), `subnetworkId` not the all-zero subnetwork, or any input `sequence !== 0n`. Field types and zero values taken from `wasm/core/kaspa.d.ts`, not guessed. Non-throwing and fail-closed: a transaction whose fields cannot be read cannot be proven safe.
- **`LedgerSignAndBroadcast`** refuses upfront, alongside the existing `hasScriptOptions` gate. One exported constant, `LEDGER_UNSIGNABLE_FIELDS_MESSAGE`, feeds both the dApp rejection and the `LedgerNotSupported` `detail` prop so the two reasons cannot drift: *"Ledger can't verify this transaction's memo, time lock, or other advanced fields yet. Try a hot wallet account instead."* Refusal dispatch uses the once-per-mount pattern from #308 so each requestId produces exactly one response.
- This also covers dApp `sendSompi`, whose optional `payload` reaches the same popup — previously that payload was silently stripped after Ledger approval.

Unblock for actually signing these fields: KAS-002 A2 (Ledger app support).

## Deliberately untouched

`lib/wallet/account/ledger-account.ts`, `lib/kaspa.ts`, `package*.json` (all 0-byte diffs), hot-wallet paths, and the internal Send flow — Generator-built transactions carry every guarded field at its default, proven by test.

## Tests

5 new cases in `tests/signtx-unit.spec.ts`: each guarded field trips the gate (incl. `sequence = u64::MAX`), a fully-default tx passes, empty-payload variants pass, malformed/sparse inputs fail closed without throwing, and a Generator-built internal-Send-shape tx passes. Suite: 25/25. The React screens have no component harness, so the predicate is what gets covered.

## Verification

- compile / lint (baseline) / prettier clean; e2e no new failures (26/26 on the final run).
- Device QA on a real Ledger (2026-08-25): baseline dApp `signAndBroadcastTx` broadcasts end-to-end (`ba5081c8…`); lockTime / sequence / payload each refused upfront with **no device prompt** and the approved copy on screen and dApp side; `sendKaspa` + payload refused; internal popup Send reaches the device prompt; hot-wallet controls sign all tampered cases normally (guard is Ledger-only); #306 regression: `None` refused, `Single` warns then signs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ledger signing now rejects malformed transactions and transactions containing unsupported advanced fields before device interaction.
  * Empty payload representations and valid internally generated transactions continue to be accepted.
  * Rejections now provide clear details and return only one response per signing request.
* **Tests**
  * Added coverage for supported and unsupported transaction fields, malformed data, and valid generated transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->