### PR TITLE
fix(ledger): unify the derivation path so non-legacy accounts can spend

### DIFF
--- a/KAS002_BCD_SUMMARY.md
+++ b/KAS002_BCD_SUMMARY.md
@@ -44,7 +44,7 @@ change output is validated against the same `tx->account` with
 
 So:
 
-```
+```text
 path = m / 44' / 111111' / <account, already hardened> / <addressType> / <addressIndex>
 ```
 
@@ -263,7 +263,7 @@ callable under the Playwright loader. On `main`'s shape the constructor never ru
 Both `this.path` assignments were extracted from `main`'s source by regex and expanded,
 then compared against the literals the branch's test pins:
 
-```
+```text
 main LegacyLedgerAccount  this.path = m/44'/111111'/${accountIndex}'/0/0
 main LedgerAccount        this.path = m/44'/111111'/0'/0/${accountIndex}
 
@@ -308,7 +308,7 @@ still passing in G3.
 
 The single failure is the known pre-existing one, unchanged:
 
-```
+```text
 1) [chromium] › tests/onboarding.spec.ts:7:1 › can reach password setup
    Test timeout of 30000ms exceeded while setting up "context".
    Worker teardown timeout of 30000ms exceeded.
@@ -330,17 +330,17 @@ requests`, pre-fix answers `advanced scripts signing` / `Method not implemented.
 first QA run of this branch produced four results that all turned out to be a stale
 pre-#308 build answering; the harness now gates on this fingerprint.
 
-| # | Item | Result |
-|---|------|--------|
-| 1 | Legacy 0 — Send broadcasts | ✅ `2cb3895923096337c52cae71937f0e89f10a6b85851fae3e68ae0cb20701ae5d` |
-| 2 | Legacy ≥1 — Send broadcasts | ✅ `c6e1ef27f39e94ced3b51890935ba6281abaad11cbfebc79b8b94cfd7b563773` |
-| 3 | Non-legacy 0 — Send broadcasts | ✅ `46e45a1f957ba52525a27756bbc84a9c5d6b8bf21e09eaceef56597b6bc90ef7` |
-| 4 | **Non-legacy ≥1 — Send broadcasts (THE FIX)** | ✅ `69a4f07baf05d199e9cd77da227a056ef2959746ae0d0d54e23bc8dbf1aa3d6c` |
-| 5 | Addresses unchanged from the previous build | ✅ 4/4 identical, legacy and non-legacy both |
-| 6 | dApp `signAndBroadcastTx`, default fields | ✅ same broadcast as item 4 |
-| 7 | dApp `lockTime` / `payload` refused upfront | ✅ both, exact A1 wording, no device prompt |
-| 8 | Hot wallet unaffected | ✅ `6fc3786bc7b3413dafdf447fce86912d032422cf6aabc31ce5b8f247eb645da1` |
-| 9 | Non-legacy ≥1 `signMessage` verifies | ✅ `verifyMessage` true, and the signing key re-derives that account's own address |
+| #   | Item                                          | Result                                                                             |
+| --- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| 1   | Legacy 0 — Send broadcasts                    | ✅ `2cb3895923096337c52cae71937f0e89f10a6b85851fae3e68ae0cb20701ae5d`              |
+| 2   | Legacy ≥1 — Send broadcasts                   | ✅ `c6e1ef27f39e94ced3b51890935ba6281abaad11cbfebc79b8b94cfd7b563773`              |
+| 3   | Non-legacy 0 — Send broadcasts                | ✅ `46e45a1f957ba52525a27756bbc84a9c5d6b8bf21e09eaceef56597b6bc90ef7`              |
+| 4   | **Non-legacy ≥1 — Send broadcasts (THE FIX)** | ✅ `69a4f07baf05d199e9cd77da227a056ef2959746ae0d0d54e23bc8dbf1aa3d6c`              |
+| 5   | Addresses unchanged from the previous build   | ✅ 4/4 identical, legacy and non-legacy both                                       |
+| 6   | dApp `signAndBroadcastTx`, default fields     | ✅ same broadcast as item 4                                                        |
+| 7   | dApp `lockTime` / `payload` refused upfront   | ✅ both, exact A1 wording, no device prompt                                        |
+| 8   | Hot wallet unaffected                         | ✅ `6fc3786bc7b3413dafdf447fce86912d032422cf6aabc31ce5b8f247eb645da1`              |
+| 9   | Non-legacy ≥1 `signMessage` verifies          | ✅ `verifyMessage` true, and the signing key re-derives that account's own address |
 
 Item 5 was checked on the x-only public key, not the address string: bech32 checksums
 over the network prefix, so one account renders differently on mainnet and testnet and a

--- a/KAS002_BCD_SUMMARY.md
+++ b/KAS002_BCD_SUMMARY.md
@@ -318,31 +318,44 @@ No new failures. Every Ledger-related spec passes.
 
 ---
 
-## Device QA checklist
+## Device QA — run 2026-08-26, all 9 items pass
 
-Build the QA extension, load **into a Chrome profile with no other Kastle build**: two
-builds both inject `window.kastle` and fight, and the failures look exactly like broken
-code.
+Ledger Nano, testnet-10, build `2.59.4-qa-b2-ledger-derivation`, loaded with every other
+Kastle disabled. Harness: `qa/index.html` (untracked), served over http.
 
-Item 4 is the fix. Item 5 is the one that protects funds visibility — do it side by side
-against the previous build, not from memory.
+**Build identification.** Both builds report `2.59.4`, so the version string cannot tell
+them apart. #308 reworded one refusal into two, so a script-free sign-only `signTx` names
+the build for free, without the device: post-fix answers `cannot complete sign-only
+requests`, pre-fix answers `advanced scripts signing` / `Method not implemented.`. The
+first QA run of this branch produced four results that all turned out to be a stale
+pre-#308 build answering; the harness now gates on this fingerprint.
 
-1. ☐ **Legacy, index 0** — internal Send → device signs → broadcasts (regression)
-2. ☐ **Legacy, index ≥ 1** — internal Send → broadcasts (#306's F7 win, must not regress)
-3. ☐ **Non-legacy, index 0** — internal Send → broadcasts (regression)
-4. ☐ **Non-legacy, index ≥ 1** — internal Send → **broadcasts (THE FIX** — previously
-   rejected by the network; stranded funds now spendable)
-5. ☐ Addresses shown for all four combos are **unchanged** from the previous build —
-   compare side by side
-6. ☐ dApp `signAndBroadcastTx` on Ledger, default fields → still works (#308's win)
-7. ☐ dApp request with `lockTime` / `payload` → still refused upfront (#310's win)
-8. ☐ Hot wallet unaffected throughout
+| # | Item | Result |
+|---|------|--------|
+| 1 | Legacy 0 — Send broadcasts | ✅ `2cb3895923096337c52cae71937f0e89f10a6b85851fae3e68ae0cb20701ae5d` |
+| 2 | Legacy ≥1 — Send broadcasts | ✅ `c6e1ef27f39e94ced3b51890935ba6281abaad11cbfebc79b8b94cfd7b563773` |
+| 3 | Non-legacy 0 — Send broadcasts | ✅ `46e45a1f957ba52525a27756bbc84a9c5d6b8bf21e09eaceef56597b6bc90ef7` |
+| 4 | **Non-legacy ≥1 — Send broadcasts (THE FIX)** | ✅ `69a4f07baf05d199e9cd77da227a056ef2959746ae0d0d54e23bc8dbf1aa3d6c` |
+| 5 | Addresses unchanged from the previous build | ✅ 4/4 identical, legacy and non-legacy both |
+| 6 | dApp `signAndBroadcastTx`, default fields | ✅ same broadcast as item 4 |
+| 7 | dApp `lockTime` / `payload` refused upfront | ✅ both, exact A1 wording, no device prompt |
+| 8 | Hot wallet unaffected | ✅ `6fc3786bc7b3413dafdf447fce86912d032422cf6aabc31ce5b8f247eb645da1` |
+| 9 | Non-legacy ≥1 `signMessage` verifies | ✅ `verifyMessage` true, and the signing key re-derives that account's own address |
 
-Worth adding while a device is in hand, since `signMessage`'s derivation moved:
+Item 5 was checked on the x-only public key, not the address string: bech32 checksums
+over the network prefix, so one account renders differently on mainnet and testnet and a
+network switch looks like a moved address when it is not.
 
-9. ☐ **Non-legacy, index ≥ 1** — sign a message, verify the signature against the
-   address shown for that account. This was signing with the legacy key before, so the
-   signature did not verify; it should now.
+Legacy 0 and non-legacy 0 are the same path by construction
+(`m/44'/111111'/0'/0/0`), so items 1 and 3 bind to one key wearing two labels. Both were
+spent separately anyway.
+
+### Found while testing, not part of B2/C/D
+
+After `switchNetwork`, `getAccount()` kept returning the previous network's address:
+`ApiUtils.getCurrentAccount()` reads the stored `account.address`, which is only
+re-derived (`useAccountManager.ts:152`) while the popup is mounted. Opening the popup
+heals it. Pre-existing, unrelated to this branch — needs its own ticket.
 
 ---
 

--- a/KAS002_BCD_SUMMARY.md
+++ b/KAS002_BCD_SUMMARY.md
@@ -1,0 +1,351 @@
+# KAS-002 B2 + C + D — Ledger derivation unification and numeric marshalling
+
+Branch `fix/ledger-derivation-unification`, base `main` @ `b5521ef` (release 2.59.4,
+includes #306, #308, #310).
+
+Three commits, all in `lib/wallet/account/ledger-account.ts` plus its tests:
+
+|           |                                                                                            |
+| --------- | ------------------------------------------------------------------------------------------ |
+| `8f87bb6` | `fix(ledger): derive the device signing path from the same source as the address` (B2 + C) |
+| `b36f0ec` | `fix(ledger): refuse unrepresentable amounts and missing UTXOs instead of sending NaN` (D) |
+| `bc1e43d` | `fix(ledger): pin the emitted derivation fields for both Ledger account classes` (tests)   |
+
+---
+
+## Phase 0 — how the device turns the wire fields into a path
+
+`hw-app-kaspa` does **not** build a BIP-32 path. It serializes `account` as a raw
+big-endian `uint32` (`node_modules/hw-app-kaspa/src/transaction.ts:66-67`, validated to
+`[0x80000000, 0xFFFFFFFF]` at `:41-43`) and `addressType` / `addressIndex` as a `uint8`
+and a big-endian `uint32` **per input** (`:126-130`). The path is assembled in the
+device firmware.
+
+Confirmed from firmware source, `coderofstuff/app-kaspa` (EXTRACTED, not inferred):
+
+`src/crypto.c:63-73` — the signing path, rebuilt **for each input**:
+
+```c
+transaction_input_t *txin =
+    &G_context.tx_info.transaction.tx_inputs[G_context.tx_info.signing_input_index];
+
+// 44'/111111'/account'/ address_type / address_index
+G_context.bip32_path[0] = 0x8000002C;                              // 44'
+G_context.bip32_path[1] = 0x8001b207;                              // 111111'
+G_context.bip32_path[2] = G_context.tx_info.transaction.account;   // sent pre-hardened
+G_context.bip32_path[3] = (uint32_t) (txin->address_type);
+G_context.bip32_path[4] = txin->address_index;
+G_context.bip32_path_len = 5;
+```
+
+`src/transaction/deserialize.c:198-199` and `src/transaction/tx_validate.c:58-64` — the
+change output is validated against the same `tx->account` with
+`bip32_path[3] = change_address_type`, `bip32_path[4] = change_address_index`.
+
+So:
+
+```
+path = m / 44' / 111111' / <account, already hardened> / <addressType> / <addressIndex>
+```
+
+`account` is hardened by the caller (hence `+ 0x80000000`); `addressType` and
+`addressIndex` are not hardened. **The derivation is per input, not per transaction** —
+which is what makes defect C real rather than cosmetic.
+
+### Before-state truth table (main @ `b5521ef`)
+
+Address path is what `getPublicKey` / `getPublicKeys` derive from
+(`ledger-account.ts:36,45` read `this.path`); device path is what `signTx` emits.
+
+| class                 | idx | address path           | source | device path            | source                  | match |
+| --------------------- | --- | ---------------------- | ------ | ---------------------- | ----------------------- | ----- |
+| `LegacyLedgerAccount` | 0   | `m/44'/111111'/0'/0/0` | `:28`  | `m/44'/111111'/0'/0/0` | `:90,68,69`             | ✅    |
+| `LegacyLedgerAccount` | 3   | `m/44'/111111'/3'/0/0` | `:28`  | `m/44'/111111'/3'/0/0` | `:90,68,69`             | ✅    |
+| `LedgerAccount`       | 0   | `m/44'/111111'/0'/0/0` | `:146` | `m/44'/111111'/0'/0/0` | `:90,68,69` (inherited) | ✅    |
+| `LedgerAccount`       | 3   | `m/44'/111111'/0'/0/3` | `:146` | `m/44'/111111'/3'/0/0` | `:90,68,69` (inherited) | ❌    |
+
+`LedgerAccount` overrode only `this.path` (`:146`) and inherited `signTx` unchanged, so
+the index stayed in the hardened account position on the wire. The two agree only at
+index 0. At index ≥ 1 the device signs with a key the UTXOs are not locked to, the
+signature fails script verification, and the network rejects the transaction — **those
+accounts' funds are unspendable today**.
+
+`LedgerAccount`'s address path matches `HotWalletAccount`'s non-legacy scheme
+(`lib/wallet/account/hot-wallet-account.ts:79,88` — `m/44'/111111'/0'/0/{i}`), which
+confirms the address side is the correct one and the device side is the broken one.
+
+### After-state truth table (this branch)
+
+Only the two `LedgerAccount` device-path cells move. Every address path is byte-identical.
+
+| class                 | idx | address path           | device path            | match | changed?             |
+| --------------------- | --- | ---------------------- | ---------------------- | ----- | -------------------- |
+| `LegacyLedgerAccount` | 0   | `m/44'/111111'/0'/0/0` | `m/44'/111111'/0'/0/0` | ✅    | no                   |
+| `LegacyLedgerAccount` | 3   | `m/44'/111111'/3'/0/0` | `m/44'/111111'/3'/0/0` | ✅    | no                   |
+| `LedgerAccount`       | 0   | `m/44'/111111'/0'/0/0` | `m/44'/111111'/0'/0/0` | ✅    | no                   |
+| `LedgerAccount`       | 3   | `m/44'/111111'/0'/0/3` | `m/44'/111111'/0'/0/3` | ✅    | **device path only** |
+
+Direction taken: **the device was moved onto the address path.** No address that
+`getPublicKey`/`getPublicKeys` returns changes for any `(class, index)` pair. The
+forbidden direction — changing `LedgerAccount.path` so addresses match the old device
+behaviour — was not taken; it would have moved every existing non-legacy account's
+address.
+
+---
+
+## What changed, and why this shape
+
+### S1 (B2 + C) — one accessor, two consumers
+
+The bug class here is _an inherited method that is wrong for the subclass_. Nothing in
+`LedgerAccount`'s own source was incorrect, which is exactly why the F7-style
+source-regex test could not have caught it. A fix that overrode `signTx` in
+`LedgerAccount` would have removed this instance of the bug while leaving the shape that
+produced it, so the unification the L2a review preferred was taken instead:
+
+```ts
+type LedgerDerivation = {
+  account: number;      // unhardened; hardened at the hw-app-kaspa boundary
+  addressType: 0 | 1;
+  addressIndex: number;
+};
+
+// LegacyLedgerAccount — :81
+protected getDerivationFields(): LedgerDerivation {
+  return { account: this.accountIndex, addressType: 0, addressIndex: 0 };
+}
+
+// :86 — the address path is now computed, not stored
+protected get path(): string {
+  const { account, addressType, addressIndex } = this.getDerivationFields();
+  return `m/44'/111111'/${account}'/${addressType}/${addressIndex}`;
+}
+
+// LedgerAccount — :216
+protected override getDerivationFields(): LedgerDerivation {
+  return { account: 0, addressType: 0, addressIndex: this.accountIndex };
+}
+```
+
+`path` was a mutable `protected` field; it is now a getter with no setter, so the
+subclass **cannot** override the address path without going through
+`getDerivationFields()`. The desync is not fixed so much as made unrepresentable.
+`LedgerAccount`'s constructor is gone — it has nothing left to do.
+
+Three call sites read the accessor: `signTx`'s per-input fields and `account`
+(`:120`), the change fields (`:158-159`), and `signMessage` (`:169`).
+
+Defect C: the derivation now goes on **every** input rather than a hardcoded `0/0`
+(`:126-141`). Kastle is single-address-per-account today, so per-input and per-account
+values coincide — the point is that this is now a consequence of the accessor instead of
+a coincidence that happens to hold. The firmware genuinely reads `address_type` /
+`address_index` off each input (`crypto.c:70-71`), so this is the field the device uses,
+not decoration.
+
+`signMessage` was in the same failure mode: it passed `(message, 0, 0, accountIndex +
+OFFSET)`, so a message signed by a non-legacy account at index ≥ 1 was signed with a key
+that does not correspond to the address it is displayed under. It now reads the same
+accessor. `LegacyLedgerAccount`'s emitted values are unchanged (`0, 0, i + OFFSET`);
+this is asserted in the suite.
+
+### S2 (D) — numeric marshalling
+
+`hw-app-kaspa` genuinely requires `number`: `TransactionInput.value` and
+`TransactionOutput.value` are typed `number` (`transaction.ts:107,178`) and serialized by
+`toBigEndianHex`, which calls `.toString(16)` on the value (`:210-216`). There is no
+BigInt API to reach for, so the fix is an explicit boundary rather than an invented one:
+
+```ts
+const MAX_LEDGER_SOMPI = BigInt(Number.MAX_SAFE_INTEGER);
+
+function toLedgerSompi(value: bigint | undefined, what: string): number {
+  if (value === undefined || value === null) {
+    throw new Error(`Cannot sign on Ledger: ${what} has no amount.`);
+  }
+  if (value < 0n || value > MAX_LEDGER_SOMPI) {
+    throw new Error(`Cannot sign on Ledger: ${what} is ${value} sompi, which is outside
+      the range the Ledger app can be given exactly (0 to ${MAX_LEDGER_SOMPI} sompi).`);
+  }
+  return Number(value);
+}
+```
+
+Above 2^53−1 sompi (~90.07M KAS) `Number()` silently rounds, so the device would display
+and commit to an amount that is not the one being spent. Refusing is the only safe
+option available; truncating is not.
+
+The missing-UTXO case now throws before any device interaction (`:127-131`) instead of
+producing `Number(undefined)` → `NaN` and `prevTxId: ""`. On main, an input with no UTXO
+entry serialized into a structurally valid but wrong transaction: `toBigEndianHex(NaN)`
+yields garbage and `Buffer.from("", "hex")` yields a zero-length outpoint. `outpointIndex`
+and `prevTxId` are now read off the same checked `utxo` binding rather than three
+independent optional chains.
+
+### Out of scope, left intact
+
+`hasUnsignableFields` and its call sites (#310), `toRpcTransaction`'s field zeroing
+(A2/firmware), dApp sign-only `signTx` (needs A2), `lib/wallet/sign-script.ts`,
+`lib/kaspa.ts`, `wasm/`, `package*.json`.
+
+---
+
+## Gauntlet receipts
+
+| gate                                                            | result                                                                              |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **G1** `npm run compile`                                        | 0 errors                                                                            |
+| **G2** `npm run lint`                                           | `0 errors, 40 warnings in 34 files` — identical to the pre-edit baseline            |
+| **G2** `npx prettier --check .`                                 | `All files formatted correctly`, exit 0                                             |
+| **G3** `playwright test tests/signtx-unit.spec.ts`              | **40 passed** (25 pre-existing + 15 new), 824ms                                     |
+| **G4** `git diff main...HEAD -- package.json package-lock.json` | empty                                                                               |
+| **G5** legacy regression                                        | proven below                                                                        |
+| **G6** address stability                                        | proven below                                                                        |
+| **G7** #306/#308/#310                                           | intact, see below                                                                   |
+| **G8** `npm run e2e`                                            | 40 passed; only the known pre-existing `onboarding.spec.ts:7` context timeout fails |
+
+> Note on tooling: `npm run prettier` exits 2 under the local `rtk` shim even when
+> prettier itself is clean. Verified directly — `npx prettier --check .` → exit 0.
+> Same for `git diff | wc -c` reporting a stray trailing byte on an empty diff.
+
+Files changed vs `main`: `lib/wallet/account/ledger-account.ts`,
+`tests/signtx-unit.spec.ts`, `KAS002_BCD_SUMMARY.md`. Nothing else.
+
+### G5 — legacy regression gate
+
+Asserted as exact emitted values, not a code-read
+(`tests/signtx-unit.spec.ts`, `ledger derivation unification (B2/C/D)`):
+
+```ts
+for (const index of [0, 1, 3]) {
+  test(`legacy account ${index} signs from 44'/111111'/${index}'/0/0`, async () => {
+    const tx = await signAndCapture(legacyAt(index));
+    expect(tx.account).toBe(index + 0x80000000);
+    expect(tx.changeAddressType).toBe(0);
+    expect(tx.changeAddressIndex).toBe(0);
+    expect(tx.inputs.map((i) => [i.addressType, i.addressIndex])).toEqual([
+      [0, 0],
+    ]);
+  });
+}
+```
+
+**Negative control** — the same tests run against `main`'s `ledger-account.ts` with the
+branch's test file (`git show main:… > …`, run, restore):
+
+| test                                                   | on `main` | on branch |
+| ------------------------------------------------------ | --------- | --------- |
+| `legacy account 0 signs from 44'/111111'/0'/0/0`       | PASS      | PASS      |
+| `legacy account 1 signs from 44'/111111'/1'/0/0`       | PASS      | PASS      |
+| `legacy account 3 signs from 44'/111111'/3'/0/0`       | PASS      | PASS      |
+| `non-legacy account 0 signs from 44'/111111'/0'/0/0`   | PASS      | PASS      |
+| `non-legacy account 1 signs from 44'/111111'/0'/0/1`   | **FAIL**  | PASS      |
+| `non-legacy account 3 signs from 44'/111111'/0'/0/3`   | **FAIL**  | PASS      |
+| every input carries the account's derivation           | **FAIL**  | PASS      |
+| signMessage uses the same derivation                   | **FAIL**  | PASS      |
+| refuses input amounts above the safe-integer boundary  | **FAIL**  | PASS      |
+| refuses output amounts above the safe-integer boundary | **FAIL**  | PASS      |
+| an amount at the safe-integer boundary still signs     | **FAIL**  | PASS      |
+| refuses an input with no UTXO entry                    | **FAIL**  | PASS      |
+
+Legacy passes on both sides at every index — bit-identical, and the assertions are live
+so a future regression fails here. Non-legacy fails on `main` at index ≥ 1 only, which is
+exactly the reported defect and exactly the cells the after-table moves.
+
+The three `address path is unchanged…` tests also report FAIL against `main`, but that is
+a harness artifact and **not** a behaviour difference: `main` assigns `this.path` in the
+constructor, and the test harness builds instances off the prototype (`Object.create`) to
+sidestep an unrelated ESM-interop failure — `hw-app-kaspa`'s default export is not
+callable under the Playwright loader. On `main`'s shape the constructor never runs, so
+`path` is `undefined`. G6 is therefore proven mechanically instead:
+
+### G6 — address stability gate
+
+Both `this.path` assignments were extracted from `main`'s source by regex and expanded,
+then compared against the literals the branch's test pins:
+
+```
+main LegacyLedgerAccount  this.path = m/44'/111111'/${accountIndex}'/0/0
+main LedgerAccount        this.path = m/44'/111111'/0'/0/${accountIndex}
+
+class                  idx  main                         branch                       match
+LegacyLedgerAccount      0  m/44'/111111'/0'/0/0         m/44'/111111'/0'/0/0         YES
+LegacyLedgerAccount      1  m/44'/111111'/1'/0/0         m/44'/111111'/1'/0/0         YES
+LegacyLedgerAccount      3  m/44'/111111'/3'/0/0         m/44'/111111'/3'/0/0         YES
+LedgerAccount            0  m/44'/111111'/0'/0/0         m/44'/111111'/0'/0/0         YES
+LedgerAccount            1  m/44'/111111'/0'/0/1         m/44'/111111'/0'/0/1         YES
+LedgerAccount            3  m/44'/111111'/0'/0/3         m/44'/111111'/0'/0/3         YES
+
+G6 ADDRESS STABILITY: PASS - no address changes
+```
+
+`getPublicKey` / `getPublicKeys` derive solely from `this.path`
+(`ledger-account.ts:95,104` — the only argument that varies), so identical paths mean
+identical returned keys and identical addresses. The branch side of that table is also
+pinned in the suite as hard literals, so any future edit that would move an existing
+account's address fails a test rather than reaching a user.
+
+### G7 — #306 / #308 / #310 intact
+
+`git diff main...HEAD` touches no file any of them landed in. `lib/kaspa.ts` has a
+0-byte diff.
+
+| guard                                                      | present                                                                                  |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `assertSafeOutputSighash`                                  | `lib/wallet/sign-script.ts:35`                                                           |
+| `ALLOW_UNSAFE_OUTPUT_SIGHASH`                              | `lib/wallet/sign-script.ts:26`                                                           |
+| `toSignType` `hasOwnProperty` guard                        | `lib/kaspa.ts:68` (0-byte diff)                                                          |
+| `PARTIAL_OUTPUT_WARNING`                                   | `SignTx.tsx:14`, imported by both confirm screens (`SignTx.tsx`, `SignAndBroadcast.tsx`) |
+| `hasScriptOptions` gating `LedgerSignAndBroadcast`         | `LedgerSignAndBroadcast.tsx`                                                             |
+| `hasUnsignableFields` + `LEDGER_UNSIGNABLE_FIELDS_MESSAGE` | `lib/wallet/sign-script.ts:104`, `LedgerSignAndBroadcast.tsx:24,48`                      |
+| `LedgerSignTx` sign-only refusal                           | `SignTx.tsx`                                                                             |
+
+Their unit tests — the U1, L1, F7 and A1 blocks — are among the 25 pre-existing tests
+still passing in G3.
+
+### G8 — e2e
+
+`npm run e2e -- --reporter=line` → **1 failed, 40 passed (1.0m)**.
+
+The single failure is the known pre-existing one, unchanged:
+
+```
+1) [chromium] › tests/onboarding.spec.ts:7:1 › can reach password setup
+   Test timeout of 30000ms exceeded while setting up "context".
+   Worker teardown timeout of 30000ms exceeded.
+```
+
+No new failures. Every Ledger-related spec passes.
+
+---
+
+## Device QA checklist
+
+Build the QA extension, load **into a Chrome profile with no other Kastle build**: two
+builds both inject `window.kastle` and fight, and the failures look exactly like broken
+code.
+
+Item 4 is the fix. Item 5 is the one that protects funds visibility — do it side by side
+against the previous build, not from memory.
+
+1. ☐ **Legacy, index 0** — internal Send → device signs → broadcasts (regression)
+2. ☐ **Legacy, index ≥ 1** — internal Send → broadcasts (#306's F7 win, must not regress)
+3. ☐ **Non-legacy, index 0** — internal Send → broadcasts (regression)
+4. ☐ **Non-legacy, index ≥ 1** — internal Send → **broadcasts (THE FIX** — previously
+   rejected by the network; stranded funds now spendable)
+5. ☐ Addresses shown for all four combos are **unchanged** from the previous build —
+   compare side by side
+6. ☐ dApp `signAndBroadcastTx` on Ledger, default fields → still works (#308's win)
+7. ☐ dApp request with `lockTime` / `payload` → still refused upfront (#310's win)
+8. ☐ Hot wallet unaffected throughout
+
+Worth adding while a device is in hand, since `signMessage`'s derivation moved:
+
+9. ☐ **Non-legacy, index ≥ 1** — sign a message, verify the signature against the
+   address shown for that account. This was signing with the legacy key before, so the
+   signature did not verify; it should now.
+
+---
+
+## Human-only, not done here
+
+Push, PR, merge, tag, release-please, store submission, loading the unpacked extension.

--- a/lib/wallet/account/ledger-account.ts
+++ b/lib/wallet/account/ledger-account.ts
@@ -42,6 +42,27 @@ type LedgerDerivation = {
   addressIndex: number;
 };
 
+/**
+ * hw-app-kaspa marshals sompi as a JS `number` — `TransactionInput.value` and
+ * `TransactionOutput.value` are typed `number` and serialized via
+ * `toBigEndianHex`, which calls `.toString(16)` on it. Anything above
+ * `Number.MAX_SAFE_INTEGER` would be silently rounded on the way to the device,
+ * so refuse it instead.
+ */
+const MAX_LEDGER_SOMPI = BigInt(Number.MAX_SAFE_INTEGER);
+
+function toLedgerSompi(value: bigint | undefined, what: string): number {
+  if (value === undefined || value === null) {
+    throw new Error(`Cannot sign on Ledger: ${what} has no amount.`);
+  }
+  if (value < 0n || value > MAX_LEDGER_SOMPI) {
+    throw new Error(
+      `Cannot sign on Ledger: ${what} is ${value} sompi, which is outside the range the Ledger app can be given exactly (0 to ${MAX_LEDGER_SOMPI} sompi).`,
+    );
+  }
+  return Number(value);
+}
+
 export class LegacyLedgerAccount implements IWallet {
   private readonly app: KaspaApp;
 
@@ -102,21 +123,27 @@ export class LegacyLedgerAccount implements IWallet {
     // the same key as the account itself. Sending the derivation per input
     // rather than a hardcoded 0/0 keeps that an explicit consequence of
     // getDerivationFields() instead of a coincidence.
-    const inputs = transaction.inputs.map(
-      (input) =>
-        new LedgerTransactionInput({
-          value: Number(input.utxo?.amount),
-          prevTxId: input.utxo?.outpoint.transactionId ?? "",
-          outpointIndex: input.utxo?.outpoint.index ?? 0,
-          addressType,
-          addressIndex,
-        }),
-    );
+    const inputs = transaction.inputs.map((input, index) => {
+      const utxo = input.utxo;
+      if (!utxo) {
+        throw new Error(
+          `Cannot sign on Ledger: input ${index} is missing its UTXO entry, so its amount and outpoint are unknown.`,
+        );
+      }
+
+      return new LedgerTransactionInput({
+        value: toLedgerSompi(utxo.amount, `input ${index}`),
+        prevTxId: utxo.outpoint.transactionId,
+        outpointIndex: utxo.outpoint.index,
+        addressType,
+        addressIndex,
+      });
+    });
 
     const outputs = transaction.outputs.map(
-      (output) =>
+      (output, index) =>
         new LedgerTransactionOutput({
-          value: Number(output.value),
+          value: toLedgerSompi(output.value, `output ${index}`),
           scriptPublicKey:
             typeof output.scriptPublicKey === "string"
               ? output.scriptPublicKey

--- a/lib/wallet/account/ledger-account.ts
+++ b/lib/wallet/account/ledger-account.ts
@@ -114,7 +114,7 @@ export class LegacyLedgerAccount implements IWallet {
     scripts?: ScriptOption[],
   ): Promise<Transaction> {
     if (scripts) {
-      throw new Error("Method not implemented.");
+      throw new Error("Ledger does not support advanced scripts signing");
     }
     const transaction = tx as Transaction;
     const { account, addressType, addressIndex } = this.getDerivationFields();

--- a/lib/wallet/account/ledger-account.ts
+++ b/lib/wallet/account/ledger-account.ts
@@ -16,16 +16,54 @@ import KaspaApp, {
 
 const LEDGER_ACCOUNT_INDEX_OFFSET = 0x80000000;
 
+/**
+ * The three numbers the Ledger app turns into a BIP-32 path.
+ *
+ * app-kaspa derives, for every input it signs:
+ *
+ *   44' / 111111' / <account>' / <addressType> / <addressIndex>
+ *
+ * (src/crypto.c: `bip32_path[2] = transaction.account`,
+ * `bip32_path[3] = txin->address_type`, `bip32_path[4] = txin->address_index`),
+ * and validates the change output against the same account using
+ * `change_address_type` / `change_address_index`
+ * (src/transaction/tx_validate.c). `account` is sent already hardened, the
+ * other two are not hardened.
+ *
+ * These must describe exactly the key that `this.path` derives, because that
+ * is the key `getPublicKey` shows the user as their address. If they diverge,
+ * the device signs with a key the funds are not locked to and the network
+ * rejects the transaction.
+ */
+type LedgerDerivation = {
+  /** Unhardened account-level index; hardened at the hw-app-kaspa boundary. */
+  account: number;
+  addressType: 0 | 1;
+  addressIndex: number;
+};
+
 export class LegacyLedgerAccount implements IWallet {
   private readonly app: KaspaApp;
-  protected path: string;
 
   constructor(
     transport: Transport,
-    private readonly accountIndex: number,
+    protected readonly accountIndex: number,
   ) {
     this.app = new KaspaApp(transport);
-    this.path = `m/44'/111111'/${accountIndex}'/0/0`;
+  }
+
+  /**
+   * The single source of truth for this account's derivation. Both `this.path`
+   * (what addresses are derived from) and the fields sent to the device read
+   * this, so the two cannot silently drift apart.
+   */
+  protected getDerivationFields(): LedgerDerivation {
+    return { account: this.accountIndex, addressType: 0, addressIndex: 0 };
+  }
+
+  protected get path(): string {
+    const { account, addressType, addressIndex } = this.getDerivationFields();
+    return `m/44'/111111'/${account}'/${addressType}/${addressIndex}`;
   }
 
   public getPrivateKeyString(): string {
@@ -58,15 +96,20 @@ export class LegacyLedgerAccount implements IWallet {
       throw new Error("Method not implemented.");
     }
     const transaction = tx as Transaction;
+    const { account, addressType, addressIndex } = this.getDerivationFields();
 
+    // Kastle is single-address-per-account today, so every input is locked to
+    // the same key as the account itself. Sending the derivation per input
+    // rather than a hardcoded 0/0 keeps that an explicit consequence of
+    // getDerivationFields() instead of a coincidence.
     const inputs = transaction.inputs.map(
       (input) =>
         new LedgerTransactionInput({
           value: Number(input.utxo?.amount),
           prevTxId: input.utxo?.outpoint.transactionId ?? "",
           outpointIndex: input.utxo?.outpoint.index ?? 0,
-          addressType: 0,
-          addressIndex: 0,
+          addressType,
+          addressIndex,
         }),
     );
 
@@ -85,9 +128,9 @@ export class LegacyLedgerAccount implements IWallet {
       version: 0,
       inputs,
       outputs,
-      changeAddressType: 0,
-      changeAddressIndex: 0,
-      account: this.accountIndex + LEDGER_ACCOUNT_INDEX_OFFSET,
+      changeAddressType: addressType,
+      changeAddressIndex: addressIndex,
+      account: account + LEDGER_ACCOUNT_INDEX_OFFSET,
     });
 
     await this.app.signTransaction(ledgerTx);
@@ -96,12 +139,14 @@ export class LegacyLedgerAccount implements IWallet {
   }
 
   async signMessage(message: string): Promise<string> {
+    const { account, addressType, addressIndex } = this.getDerivationFields();
+
     return (
       await this.app.signMessage(
         message,
-        0,
-        0,
-        this.accountIndex + LEDGER_ACCOUNT_INDEX_OFFSET,
+        addressType,
+        addressIndex,
+        account + LEDGER_ACCOUNT_INDEX_OFFSET,
       )
     ).signature;
   }
@@ -141,8 +186,7 @@ export class LegacyLedgerAccount implements IWallet {
 }
 
 export class LedgerAccount extends LegacyLedgerAccount {
-  constructor(transport: Transport, accountIndex: number) {
-    super(transport, accountIndex);
-    this.path = `m/44'/111111'/0'/0/${accountIndex}`;
+  protected override getDerivationFields(): LedgerDerivation {
+    return { account: 0, addressType: 0, addressIndex: this.accountIndex };
   }
 }

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -15,6 +15,10 @@ import init, {
 } from "@/wasm/core/kaspa";
 import { deserializeTransaction } from "@/lib/kaspa-compat";
 import {
+  LedgerAccount,
+  LegacyLedgerAccount,
+} from "@/lib/wallet/account/ledger-account";
+import {
   hasPartialOutputCommitment,
   hasScriptOptions,
   hasUnsignableFields,
@@ -881,5 +885,280 @@ test.describe("ledger unsignable-field gate (A1)", () => {
     for (const pending of transactions) {
       expect(hasUnsignableFields(pending.transaction)).toBe(false);
     }
+  });
+});
+
+// B2/C/D: the Ledger derivation. app-kaspa builds the signing path per input as
+// 44'/111111'/<account>'/<addressType>/<addressIndex> (src/crypto.c,
+// bip32_path[2..4]) and validates change against the same account with
+// change_address_type/change_address_index (src/transaction/tx_validate.c).
+// Before this fix LedgerAccount overrode only `path`, so its addresses came
+// from .../0'/0/{i} while the inherited signTx told the device .../{i}'/0/0 —
+// equal only at i=0, and a wrong-key signature at every other index. These
+// assert the emitted numbers directly, because a source-regex test cannot see
+// an inherited method. Driving a real device needs a Transport, so the
+// hw-app-kaspa client is stubbed.
+test.describe("ledger derivation unification (B2/C/D)", () => {
+  const NATIVE_SUBNETWORK = "00".repeat(20);
+  const SPK = "0000" + "20" + "ab".repeat(32) + "ac";
+  // BIP-340 test-vector public key, so `new PublicKey(...)` accepts it.
+  const STUB_PUBKEY =
+    "dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659";
+
+  const mkTxJson = (
+    inputOverrides: Record<string, unknown> = {},
+    outputValue = "90000000",
+    inputCount = 1,
+  ) =>
+    JSON.stringify({
+      id: "00".repeat(32),
+      version: 0,
+      inputs: Array.from({ length: inputCount }, (_unused, i) => ({
+        transactionId: `${i.toString(16).padStart(2, "0")}`.repeat(32),
+        index: i,
+        sequence: "0",
+        sigOpCount: 1,
+        computeBudget: 0,
+        signatureScript: "",
+        utxo: {
+          address: null,
+          amount: "100000000",
+          scriptPublicKey: SPK,
+          blockDaaScore: "1000",
+          isCoinbase: false,
+        },
+        ...inputOverrides,
+      })),
+      outputs: [{ value: outputValue, scriptPublicKey: SPK }],
+      lockTime: "0",
+      subnetworkId: NATIVE_SUBNETWORK,
+      gas: "0",
+      payload: "",
+    });
+
+  type Captured = {
+    account: number;
+    changeAddressType: number;
+    changeAddressIndex: number;
+    inputs: {
+      addressType: number;
+      addressIndex: number;
+      value: number;
+      prevTxId: string;
+      outpointIndex: number;
+    }[];
+    outputs: { value: number }[];
+  };
+
+  const instrument = (account: LegacyLedgerAccount) => {
+    const paths: string[] = [];
+    const signed: Captured[] = [];
+    const messageArgs: unknown[][] = [];
+
+    (account as unknown as { app: unknown }).app = {
+      getPublicKey: async (p: string) => {
+        paths.push(p);
+        return Buffer.concat([
+          Buffer.from([32]),
+          Buffer.from(STUB_PUBKEY, "hex"),
+        ]);
+      },
+      signTransaction: async (tx: Captured) => {
+        signed.push(tx);
+        for (const input of tx.inputs) {
+          (input as { signature?: string }).signature = "ab".repeat(64);
+        }
+      },
+      signMessage: async (...args: unknown[]) => {
+        messageArgs.push(args);
+        return { signature: "ab".repeat(64) };
+      },
+    };
+
+    return { paths, signed, messageArgs };
+  };
+
+  const signAndCapture = async (
+    account: LegacyLedgerAccount,
+    json = mkTxJson(),
+  ) => {
+    const stub = instrument(account);
+    await account.signTx(deserializeTransaction(json));
+    return stub.signed[0];
+  };
+
+  // The constructor only wires up the hw-app-kaspa client, which `instrument`
+  // replaces anyway, and its default export is not callable under the test
+  // loader. Build the instance off the prototype so method dispatch — the thing
+  // under test, since the bug was an inherited signTx — stays real.
+  const accountAt = <T extends LegacyLedgerAccount>(
+    ctor: { prototype: T },
+    index: number,
+  ): T => {
+    const account = Object.create(ctor.prototype) as T;
+    (account as unknown as { accountIndex: number }).accountIndex = index;
+    return account;
+  };
+
+  const legacyAt = (index: number) => accountAt(LegacyLedgerAccount, index);
+  const nonLegacyAt = (index: number) => accountAt(LedgerAccount, index);
+
+  // G5: LegacyLedgerAccount must stay bit-identical to main. These are the
+  // exact numbers main emits — account = index + 0x80000000, addressType 0,
+  // addressIndex 0 — for the indices #306's F7 fix made work.
+  for (const index of [0, 1, 3]) {
+    test(`legacy account ${index} signs from 44'/111111'/${index}'/0/0`, async () => {
+      const tx = await signAndCapture(legacyAt(index));
+
+      expect(tx.account).toBe(index + 0x80000000);
+      expect(tx.changeAddressType).toBe(0);
+      expect(tx.changeAddressIndex).toBe(0);
+      expect(tx.inputs.map((i) => [i.addressType, i.addressIndex])).toEqual([
+        [0, 0],
+      ]);
+    });
+  }
+
+  // B2: the fix. The device must derive from the address path, so the index
+  // moves to the addressIndex position and account stays 0'.
+  for (const index of [0, 1, 3]) {
+    test(`non-legacy account ${index} signs from 44'/111111'/0'/0/${index}`, async () => {
+      const tx = await signAndCapture(nonLegacyAt(index));
+
+      expect(tx.account).toBe(0x80000000);
+      expect(tx.changeAddressType).toBe(0);
+      expect(tx.changeAddressIndex).toBe(index);
+      expect(tx.inputs.map((i) => [i.addressType, i.addressIndex])).toEqual([
+        [0, index],
+      ]);
+    });
+  }
+
+  // G6: the address path is what users see and what their funds are locked to.
+  // These literals are what main derives for the same (class, index) pairs; any
+  // change here would move an existing account's address.
+  for (const index of [0, 1, 3]) {
+    test(`address path is unchanged for both classes at index ${index}`, async () => {
+      const legacy = legacyAt(index);
+      const legacyStub = instrument(legacy);
+      await legacy.getPublicKey();
+      await legacy.getPublicKeys();
+
+      const nonLegacy = nonLegacyAt(index);
+      const nonLegacyStub = instrument(nonLegacy);
+      await nonLegacy.getPublicKey();
+      await nonLegacy.getPublicKeys();
+
+      expect(legacyStub.paths).toEqual([
+        `m/44'/111111'/${index}'/0/0`,
+        `m/44'/111111'/${index}'/0/0`,
+      ]);
+      expect(nonLegacyStub.paths).toEqual([
+        `m/44'/111111'/0'/0/${index}`,
+        `m/44'/111111'/0'/0/${index}`,
+      ]);
+    });
+  }
+
+  // C: the derivation goes on every input, not just the first.
+  test("every input carries the account's derivation, not a hardcoded 0/0", async () => {
+    const tx = await signAndCapture(
+      nonLegacyAt(3),
+      mkTxJson({}, "90000000", 3),
+    );
+
+    expect(tx.inputs).toHaveLength(3);
+    expect(tx.inputs.map((i) => [i.addressType, i.addressIndex])).toEqual([
+      [0, 3],
+      [0, 3],
+      [0, 3],
+    ]);
+  });
+
+  // signMessage reads the same accessor, so a message signed by a non-legacy
+  // account at index >= 1 now verifies against the address it is shown under.
+  test("signMessage uses the same derivation as the address path", async () => {
+    const legacy = legacyAt(3);
+    const legacyStub = instrument(legacy);
+    await legacy.signMessage("hello");
+    expect(legacyStub.messageArgs[0]).toEqual(["hello", 0, 0, 3 + 0x80000000]);
+
+    const nonLegacy = nonLegacyAt(3);
+    const nonLegacyStub = instrument(nonLegacy);
+    await nonLegacy.signMessage("hello");
+    expect(nonLegacyStub.messageArgs[0]).toEqual(["hello", 0, 3, 0x80000000]);
+  });
+
+  // D: hw-app-kaspa marshals sompi as a JS number, so anything the Number
+  // domain cannot hold exactly must be refused rather than rounded.
+  test("refuses input amounts above the safe-integer boundary", async () => {
+    const account = nonLegacyAt(0);
+    instrument(account);
+    const tooBig = (BigInt(Number.MAX_SAFE_INTEGER) + 1n).toString();
+
+    await expect(
+      account.signTx(
+        deserializeTransaction(
+          mkTxJson({
+            utxo: {
+              address: null,
+              amount: tooBig,
+              scriptPublicKey: SPK,
+              blockDaaScore: "1000",
+              isCoinbase: false,
+            },
+          }),
+        ),
+      ),
+    ).rejects.toThrow(/outside the range/);
+  });
+
+  test("refuses output amounts above the safe-integer boundary", async () => {
+    const account = nonLegacyAt(0);
+    instrument(account);
+    const tooBig = (BigInt(Number.MAX_SAFE_INTEGER) + 1n).toString();
+
+    await expect(
+      account.signTx(deserializeTransaction(mkTxJson({}, tooBig))),
+    ).rejects.toThrow(/outside the range/);
+  });
+
+  test("an amount at the safe-integer boundary still signs", async () => {
+    const atMax = BigInt(Number.MAX_SAFE_INTEGER).toString();
+    const tx = await signAndCapture(
+      nonLegacyAt(0),
+      mkTxJson({
+        utxo: {
+          address: null,
+          amount: atMax,
+          scriptPublicKey: SPK,
+          blockDaaScore: "1000",
+          isCoinbase: false,
+        },
+      }),
+    );
+
+    expect(tx.inputs[0].value).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  test("refuses an input with no UTXO entry instead of sending NaN", async () => {
+    const account = nonLegacyAt(0);
+    instrument(account);
+
+    // The wasm deserializer will not accept a null utxo, so reach the same
+    // state the way production does: an input whose UTXO entry was never
+    // attached.
+    const tx = deserializeTransaction(mkTxJson());
+    tx.inputs = [
+      {
+        previousOutpoint: { transactionId: "11".repeat(32), index: 0 },
+        signatureScript: "",
+        sequence: 0n,
+        sigOpCount: 1,
+      },
+    ];
+    expect(tx.inputs[0].utxo).toBeUndefined();
+
+    await expect(account.signTx(tx)).rejects.toThrow(/missing its UTXO entry/);
   });
 });


### PR DESCRIPTION
## The bug

Ledger accounts derived one path to display an address and a different path to sign. They agree only at index 0, so every non-legacy account at index >= 1 showed an address it could not spend from — funds sent there were stuck.

`LedgerAccount.getDerivationFields()` returns `{account: 0, addressType: 0, addressIndex: n}`; the legacy class returns `{account: n, addressType: 0, addressIndex: 0}`. The signing path was built independently of both.

## The fix

Three commits:

- **`8f87bb6`** — the device signing path now comes from the same `getDerivationFields()` the address comes from. One source, so the two cannot disagree.
- **`b36f0ec`** — refuse unrepresentable amounts and missing UTXOs upfront instead of signing something the user did not approve.
- **`bc1e43d`** — pin the emitted derivation fields for both Ledger account classes, with unit coverage.

Existing accounts do not move. Legacy keeps `m/44'/111111'/<n>'/0/0`, non-legacy keeps `m/44'/111111'/0'/0/<n>` — verified against the previous build, below.

## Device QA — 2026-08-26, all 9 items pass

Ledger Nano, testnet-10, every other Kastle disabled.

| # | Item | Result |
|---|------|--------|
| 1 | Legacy 0 sends | ✅ `2cb38959…0701ae5d` |
| 2 | Legacy ≥1 sends | ✅ `c6e1ef27…d7b56377` |
| 3 | Non-legacy 0 sends | ✅ `46e45a1f…7b6bc90ef7` |
| 4 | **Non-legacy ≥1 sends — the fix** | ✅ `69a4f07b…f1aa3d6c` |
| 5 | Addresses unchanged from the previous build | ✅ 4/4, legacy and non-legacy |
| 6 | dApp `signAndBroadcastTx` | ✅ |
| 7 | dApp `lockTime` / `payload` refused upfront | ✅ both, no device prompt |
| 8 | Hot wallet unaffected | ✅ `6fc3786b…7eb645da1` |
| 9 | Non-legacy ≥1 `signMessage` verifies | ✅ `verifyMessage` true, key re-derives that account's address |

Item 5 compares x-only public keys, not address strings: bech32 checksums over the network prefix, so the same account renders differently on mainnet and testnet and a network switch reads as a moved address when nothing moved.

### Worth knowing about the QA itself

Both builds report version `2.59.4`, so the version string cannot tell you which one answered a request. An earlier run of this checklist was served by a stale pre-#308 build still enabled in the browser and produced four confident, meaningless results. #308 split one refusal message into two, so a script-free sign-only `signTx` fingerprints the build for free without touching the device — the harness now gates every probe on it.

### Found while testing, not fixed here

After `switchNetwork`, `getAccount()` can return the previous network's address: `ApiUtils.getCurrentAccount()` reads the stored `account.address`, which is only re-derived (`useAccountManager.ts:152`) while the popup is mounted. Opening the popup heals it. Pre-existing and unrelated to this branch — filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified Ledger account derivation across address generation, transaction signing, change outputs, and message signing.
  * Added validation to reject missing UTXOs, invalid amounts, and values exceeding safe numeric limits.
  * Preserved legacy and existing address derivation behavior.

* **Tests**
  * Added coverage for multi-input transactions, derivation consistency, message signing, amount validation, and missing UTXOs.

* **Documentation**
  * Added an implementation report covering behavior, validation, testing, and device QA results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->