### PR TITLE
fix: free WASM secret objects at last use

### DIFF
--- a/W1_INVESTIGATION.md
+++ b/W1_INVESTIGATION.md
@@ -1,0 +1,296 @@
+# W1 — WASM secret objects never freed: Phase 1 investigation
+
+Read-only. Base `main` @ `a441e75`. Node 20.20.2. All claims below were verified by
+opening `wasm/core/kaspa.js` / `kaspa.d.ts` and the call sites — no INFERRED graph edge
+is load-bearing.
+
+**Headline correction to the brief's premise.** The brief states "wasm-bindgen objects
+are not reclaimed by JS GC. Every allocation persists in WASM linear memory for the life
+of that instance." **That is false for this build.** Every secret-bearing class registers
+with a `FinalizationRegistry`, on both allocation paths. These objects _are_ reclaimed —
+just nondeterministically and late. The defect is real but it is **delayed reclamation**,
+not an unbounded leak. Section P1.1 has the receipts; P1.4 re-grades severity accordingly.
+
+---
+
+## P1.1 — Does `.free()` exist, and is there already GC-driven cleanup?
+
+Yes to both, for all four secret-bearing classes.
+
+| Class        | `free()` | FinalizationRegistry     | Registry decl    |
+| ------------ | -------- | ------------------------ | ---------------- |
+| `PrivateKey` | yes      | `PrivateKeyFinalization` | `kaspa.js:6948`  |
+| `Keypair`    | yes      | `KeypairFinalization`    | `kaspa.js:4675`  |
+| `XPrv`       | yes      | `XPrvFinalization`       | `kaspa.js:13498` |
+| `Mnemonic`   | yes      | `MnemonicFinalization`   | `kaspa.js:4918`  |
+
+```js
+// wasm/core/kaspa.js:6948
+const PrivateKeyFinalization =
+  typeof FinalizationRegistry === "undefined"
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry((ptr) =>
+        wasm.__wbg_privatekey_free(ptr >>> 0, 1),
+      );
+```
+
+**Both** allocation paths register:
+
+- `static __wrap(ptr)` — used by every method that returns a new object
+  (`kaspa.js:6961`: `PrivateKeyFinalization.register(obj, obj.__wbg_ptr, obj)`)
+- `constructor(key)` — `kaspa.js:7098`: `PrivateKeyFinalization.register(this, this.__wbg_ptr, this)`
+
+So nothing is permanently stranded. `free()` is a _deterministic, prompt_ deallocation
+in place of a nondeterministic, late one.
+
+**Why that still matters.** The JS GC sees only the ~50-byte wrapper object; the WASM-side
+allocation is invisible to its heap accounting and exerts zero collection pressure. This is
+the standard wasm-bindgen visibility gap: the registry fires eventually, on the GC's
+schedule, driven by JS-heap pressure that these objects barely contribute to. In a popup
+that allocates one `Mnemonic` per keystroke (P1.3, site 14), "eventually" is unbounded in
+practice. That is the honest case for `.free()` — not "GC never runs", but "GC has no
+visibility into the cost, so it runs far too late."
+
+**Ownership semantics (this gates whether freeing is even safe).** Verified by scanning
+each class body and the free functions for `_assertClass` (borrow-check) vs
+`__destroy_into_raw` (ownership transfer):
+
+| Callee                                   | Takes `PrivateKey` by               | Safe to `free()` after? |
+| ---------------------------------------- | ----------------------------------- | ----------------------- |
+| `createInputSignature` (`kaspa.js:1122`) | borrow (`_assertClass`, no destroy) | **yes**                 |
+| `signTransaction` (`kaspa.js:1063`)      | borrow                              | **yes**                 |
+| `signScriptHash` (`kaspa.js:1087`)       | borrow                              | **yes**                 |
+| `signMessage` (`kaspa.js:1231`)          | takes a **string**, not an object   | n/a                     |
+
+No method on any of the four classes consumes `this`. The caller always retains ownership
+and is always responsible for freeing.
+
+**Derived objects are independent allocations, not views** — the critical safety
+precondition for freeing a parent after deriving from it:
+
+| Method                             | Returns                                     |
+| ---------------------------------- | ------------------------------------------- |
+| `XPrv.derivePath` (`:13553`)       | `XPrv.__wrap(...)` — fresh allocation       |
+| `XPrv.deriveChild` (`:13611`)      | `XPrv.__wrap(...)` — fresh allocation       |
+| `XPrv.toPrivateKey` (`:13651`)     | `PrivateKey.__wrap(...)` — fresh allocation |
+| `PrivateKey.toKeypair` (`:7004`)   | `Keypair.__wrap(...)` — fresh allocation    |
+| `PrivateKey.toPublicKey` (`:7022`) | `PublicKey.__wrap(...)` — fresh allocation  |
+| `Mnemonic.toSeed` (`:4985`)        | **JS string** (`getStringFromWasm0`)        |
+| `Mnemonic.phrase` (`:5033`)        | **JS string**                               |
+| `Keypair.privateKey` (`:4763`)     | **JS string**                               |
+| `XPrv.privateKey` (`:13688`)       | **JS string**                               |
+
+Freeing an `XPrv` after `derivePath()` does not invalidate the child. Confirmed in source.
+
+---
+
+## P1.2 — Does the Rust side zeroize on drop?
+
+**`BLOCKED: needs upstream confirmation.`** Strong negative signal, not proof.
+
+The Rust source is not in the repo. The compiled binary is not vendored under `wasm/`
+either (only `kaspa.js`, `kaspa.d.ts`, `kaspa_bg.wasm.d.ts`); the binary is emitted at
+build time. Probing a built artifact (`.output/chrome-mv3/assets/kaspa_bg-*.wasm`,
+11.8 MB):
+
+| Symbol      | Occurrences |
+| ----------- | ----------- |
+| `zeroize`   | **0**       |
+| `Zeroizing` | **0**       |
+| `secp256k1` | 33          |
+| `bip32`     | 49          |
+| `panicked`  | 5           |
+| `unwrap`    | 92          |
+
+The string table is clearly **not stripped** — crate and module names survive — so the
+absence of `zeroize` carries weight. It is not conclusive: the `zeroize` crate's `Drop`
+impls are thin `write_volatile` loops that may be fully inlined and emit no string
+literals at all. Absence of the string is evidence of absence of the _dependency_, not
+proof of absence of the _behavior_.
+
+**What would settle it:** the `Cargo.toml` / `Cargo.lock` of the `kaspa-wasm` crate that
+produced this binary — is `zeroize` in the dependency tree, and do `PrivateKey` / `Keypair`
+/ `XPrv` / `Mnemonic` derive `ZeroizeOnDrop`? That is the question to raise upstream with
+`@kcoin/kaspa-web3.js`.
+
+**Consequence for Phase 2:** this is a **leak/promptness fix with only partial security
+benefit**. `free()` returns the allocation to the WASM allocator with its bytes intact;
+the secret remains readable in linear memory until something else happens to reuse that
+region. Do not describe this work as wiping keys from memory.
+
+---
+
+## P1.3 — Complete allocation-site inventory
+
+19 sites across 7 files. `.free()` appears **zero** times in `lib/`, `hooks/`, `api/`,
+`components/`, `entrypoints/` — confirmed, the brief is correct on this point.
+
+### Bucket A — local scope, safe to free in `finally`
+
+| #   | Site                                           | Class(es) allocated                                   | Notes                                                                                                                                                                                                                     |
+| --- | ---------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `lib/wallet/sign-script.ts:204`                | `PrivateKey`                                          | **Highest value.** Inline temp inside `signTxInputWithScriptOption`, called once **per input** from the loop at `:246-248`. An N-input tx allocates N. Callee borrows (P1.1) → free after `createInputSignature` returns. |
+| 2   | `hot-wallet-account.ts:15-16`                  | `Keypair` (+ `PrivateKey` from site 12)               | `getPrivateKeyString()`. Returns a string; both objects dead at return.                                                                                                                                                   |
+| 3   | `hot-wallet-account.ts:20`                     | `XPrv`                                                | `LegacyHotWalletAccount.getPublicKeys()` seed root; dead at `:32`.                                                                                                                                                        |
+| 4   | `hot-wallet-account.ts:25-27`                  | `XPrv` (derivePath temp) + `PrivateKey`               | **In a 50-iteration loop** (`MAX_DERIVATION_INDEXES = 50`).                                                                                                                                                               |
+| 5   | `hot-wallet-account.ts:29`                     | `PublicKey`                                           | Same loop. Not secret-bearing, but same leak; sites 3-5 total **150 objects per call**.                                                                                                                                   |
+| 6   | `hot-wallet-account.ts:41`                     | `PrivateKey` (temp)                                   | `getPublicKey()`. The returned `PublicKey` is bucket B — free only the `PrivateKey`.                                                                                                                                      |
+| 7   | `hot-wallet-account.ts:56`                     | `XPrv`                                                | `LegacyHotWalletAccount.getPrivateKeys()` root.                                                                                                                                                                           |
+| 8   | `hot-wallet-account.ts:60-64`                  | `XPrv` temp + `PrivateKey` + `Keypair`                | Loop over `indexes`; returns `string[]`, no WASM escapes.                                                                                                                                                                 |
+| 9   | `hot-wallet-account.ts:77-82`                  | `XPrv` + derivePath temp + `PrivateKey` + `PublicKey` | `HotWalletAccount.getPublicKeys()`.                                                                                                                                                                                       |
+| 10  | `hot-wallet-account.ts:93`                     | `PrivateKey` (temp) + `Keypair`                       | `HotWalletAccount.getPrivateKeys()`; returns `string[]`.                                                                                                                                                                  |
+| 11  | `hot-wallet-account.ts:49-51`, `86-88`         | `XPrv` + derivePath temp                              | Roots inside `getPrivateKey()`. The **returned** `PrivateKey` is bucket B; the `XPrv` and the intermediate are local and freeable here.                                                                                   |
+| 12  | `account-factory.ts:16`, `:42`                 | `Mnemonic`                                            | `Mnemonic.random(12).phrase` → string. Both `LegacyAccountFactory` and `AccountFactory`.                                                                                                                                  |
+| 13  | `account-factory.ts:28`, `:54`                 | `Mnemonic`                                            | `new Mnemonic(m).toSeed(p)` → string. Both branches.                                                                                                                                                                      |
+| 14  | `ImportRecoveryPhrase.tsx:110`                 | `Mnemonic`                                            | Validation-only, discarded. In a `useEffect` keyed `[inputWords]` → **one allocation per keystroke**, in the long-lived popup instance.                                                                                   |
+| 15  | `ImportPrivateKey.tsx:99`                      | `PrivateKey`                                          | Validation-only inside react-hook-form `validate`; result discarded. Fires per validation pass.                                                                                                                           |
+| 16  | `ImportRecoveryPhraseWithPassphrase.tsx:33`    | `Mnemonic`                                            | Validation-only, discarded.                                                                                                                                                                                               |
+| 17  | `lib/ethereum/wallet/account-factory.ts:12-18` | `Mnemonic` + `XPrv` + derivePath temp + `PrivateKey`  | `LegacyAccountFactory.createFromMnemonic`. Secret leaves as `privateKey.toString()` at `:20`.                                                                                                                             |
+| 18  | `lib/ethereum/wallet/account-factory.ts:35-41` | same four                                             | `AccountFactory.createFromMnemonic`.                                                                                                                                                                                      |
+
+Sites 17/18 each contain the `isLegacy` ternary internally (`:14-16`, `:37-39`) — the
+allocation shape is **identical on both branches**, so a single fix per method covers both.
+
+### Bucket B — returned to caller; do NOT free at the allocation site
+
+| Site                                                                   | Class        | Consumers                                                                                                      | Last use                                                                                                                                                     |
+| ---------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hot-wallet-account.ts:50-52` (`LegacyHotWalletAccount.getPrivateKey`) | `PrivateKey` | `:15` (`getPrivateKeyString`), `:41` (`getPublicKey`), `:93` (subclass `getPrivateKeys`)                       | All three consumers are **inside this class file** (`protected`, no external callers — verified by grep across `lib/ hooks/ api/ components/ entrypoints/`). |
+| `hot-wallet-account.ts:87-89` (`HotWalletAccount.getPrivateKey`)       | `PrivateKey` | same three                                                                                                     | same                                                                                                                                                         |
+| `hot-wallet-account.ts:41` (`getPublicKey` return)                     | `PublicKey`  | 12 call sites across `lib/krc20.ts`, `lib/kns.ts`, `lib/krc721.ts`, `lib/commit-reveal.ts`, `hooks/`, handlers | Not secret-bearing. Lifetime is caller-controlled and diffuse. Leave.                                                                                        |
+
+Because every consumer of the returned `PrivateKey` is local to the class, bucket B is
+**fully covered indirectly**: each consumer (sites 2, 6, 10) frees it as its own local.
+The allocation site itself stays untouched.
+
+### Bucket C — stored on an instance
+
+| Site                           | Class        | Lifecycle                                                                              |
+| ------------------------------ | ------------ | -------------------------------------------------------------------------------------- |
+| `hot-wallet-private-key.ts:15` | `PrivateKey` | ctor param retained as `private privateKey`; read by `getPublicKey()` `:24`.           |
+| `hot-wallet-private-key.ts:16` | `Keypair`    | `this.keypair`; read by `:20`, `:28`.                                                  |
+| `account-factory.ts:34`, `:60` | `PrivateKey` | `new HotWalletPrivateKey(new PrivateKey(...))` — handed straight into the field above. |
+
+**`IWallet` (`wallet-interface.ts:23-31`) declares no teardown method**, and no call site
+disposes a wallet. Adding one means changing the interface, all six implementations, and
+every construction site — well outside "call-site changes only", and with no unambiguous
+call point it would be dead code. **Treated as D. Not touched in Phase 2.**
+
+### Bucket D — ambiguous, leave alone
+
+The three bucket-C sites above, plus the `PublicKey` returned from `getPublicKey()`.
+No site required a coin-flip: every A-classification rests on a return type of `string`
+or a value dead before the function returns.
+
+### The bigger exposure that `.free()` does not touch
+
+`Mnemonic.toSeed()`, `Keypair.privateKey`, `XPrv.privateKey` and `PrivateKey.toString()`
+all return **plain JS strings** (P1.1 table). Consequently:
+
+- `LegacyHotWalletAccount` holds `protected readonly seed: string` — the **master seed**,
+  in the JS heap, for the account object's entire life (`hot-wallet-account.ts:10`).
+- `getPrivateKeyString()` hands a hex private key to `signTxWithScriptOptions` and
+  `signMessage` as a string (`:37`, `:45`).
+- `EthereumPrivateKeyAccount` receives `privateKey.toString()` (`eth account-factory.ts:20`, `:42`).
+
+JS strings are immutable and cannot be zeroed. **This is the dominant secret-in-memory
+surface in the codebase, and it is strictly larger than the WASM one.** Phase 2 does not
+address it and must not claim to.
+
+---
+
+## P1.4 — Exposure assessment
+
+Grading the two instances separately.
+
+**Background service worker.** Secrets are decrypted only for the duration of a signing
+operation and discarded after (handover §4.5); `lock()` nulls `masterKey`; Chrome reclaims
+an idle MV3 SW after ~30s, taking the entire WASM instance — linear memory and all — with
+it. Objects allocated during a sign are also `FinalizationRegistry`-eligible immediately
+after. Realistic residency: **seconds to a few minutes**, hard-bounded by SW teardown.
+
+**Popup.** Lives as long as the popup is open — typically seconds to minutes, but pinned
+open indefinitely in a side panel. `ImportRecoveryPhrase.tsx:110` allocates a `Mnemonic`
+per keystroke here, so a 24-word phrase entry leaves on the order of 100+ `Mnemonic`
+objects, each holding the **full recovery phrase**, resident until GC decides otherwise.
+That is the worst single case in the codebase — and it is exactly the moment the user's
+most sensitive secret is in play.
+
+**Verdict: Low-to-Medium, below the brief's implied Medium.** Reasons:
+
+1. The `FinalizationRegistry` (P1.1) means this is delayed reclamation, not a permanent
+   leak — the brief's premise 1 does not hold.
+2. SW teardown hard-bounds the background instance independently of anything we do.
+3. Reading WASM linear memory requires code execution in the extension's own origin.
+   An attacker with that already has the decrypted `masterKey` and the JS-heap seed
+   string — both easier targets than scavenging a WASM heap.
+4. The JS-heap strings above are a strictly larger, strictly easier target that this work
+   does not shrink at all.
+
+The genuine, defensible wins from Phase 2 are (a) bounded WASM memory growth in the popup,
+(b) a shorter and _deterministic_ residency window, (c) removing 150-object-per-call
+churn from `getPublicKeys()`. Not "keys are wiped."
+
+---
+
+## P1.5 — Test strategy
+
+The harness supports more than the brief assumed. `tests/signtx-unit.spec.ts` already
+imports `init` from `@/wasm/core/kaspa` **and** real app modules (`sign-script`,
+`ledger-account`, `kaspa-compat`), and runs node-side: **40 tests, 1.1s**. Importing
+`AccountFactory` / `LegacyAccountFactory` there is a one-line addition.
+
+Baseline captured before any edit (`w1`, node 20.20.2):
+
+| Check                                           | Baseline         |
+| ----------------------------------------------- | ---------------- |
+| `npm run compile`                               | exit 0, 0 errors |
+| `npm run lint`                                  | exit 0, clean    |
+| `npm run prettier` (`--check .`)                | exit 0, clean    |
+| `npx playwright test tests/signtx-unit.spec.ts` | **40 passed**    |
+
+Proposed tests, all in `tests/signtx-unit.spec.ts`:
+
+1. **Derivation parity, both `isLegacy` branches (G6, required).** Pin a fixed test
+   mnemonic. Assert `LegacyAccountFactory().createFromMnemonic(m, i)` and
+   `AccountFactory().createFromMnemonic(m, i)` produce the **exact expected address
+   strings**, hardcoded from a pre-change run, for several `accountIndex` values. This is
+   the wrong-key-signs guard: it fails if a `free()` corrupts a derivation on either path,
+   _and_ it fails if the two paths are ever swapped. Hardcoding the expected values (rather
+   than comparing branch-to-branch) is what makes it a real regression fence.
+2. **Signing still succeeds after free-bearing code paths run.** Drive
+   `signTxWithScriptOptions` over a multi-input tx so `sign-script.ts:204` allocates and
+   frees per input; assert every input gets a `signatureScript` and that the signatures
+   verify against the schnorr path the file already uses (`@noble/curves`).
+3. **Repeat-call stability.** Call `getPublicKeys()` and `signTx` in a loop (~20×) on both
+   account classes. A misplaced free surfaces as `null pointer passed to rust` on
+   iteration 2 — this is the cheapest possible detector for use-after-free, and it costs
+   milliseconds node-side.
+4. **Free actually happened.** Allocate a `PrivateKey`, `free()` it, assert a subsequent
+   `.toString()` throws. Proves the deallocation is real rather than a silent no-op, and
+   documents the observable semantics the other tests rely on.
+5. **`signMessage` on both branches.** Assert a stable signature for a fixed message/key
+   on `HotWalletAccount` and `LegacyHotWalletAccount`.
+
+Not proposable: any assertion about _linear memory shrinking_. `WebAssembly.Memory` never
+returns pages to the OS, and there is no exposed allocator introspection. The absence of
+this test should be stated in the summary rather than papered over.
+
+---
+
+## GATE
+
+| Criterion                                              | Status                                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `.free()` confirmed available                          | **PASS** — all four classes, `kaspa.js` decls quoted in P1.1                         |
+| Bucket (A) non-trivial                                 | **PASS** — 18 sites across 7 files, incl. a per-input allocation on the signing path |
+| Test proving signing works on both `isLegacy` branches | **PASS** — harness runs node-side with real app modules; test 1 + test 2 above       |
+| Freeing is provably safe                               | **PASS** — all callees borrow; all derived objects are independent allocations       |
+
+**PROCEED to Phase 2**, with scope explicitly bounded to bucket A, and with the severity
+claim corrected: this is a promptness/bounded-growth fix, not a leak elimination and not
+a memory-wiping fix.
+
+**Follow-ups, not this branch:** upstream `ZeroizeOnDrop` question to
+`@kcoin/kaspa-web3.js` (P1.2); the JS-heap seed/private-key strings (P1.3 last section),
+which are the larger problem; `IWallet` teardown for `HotWalletPrivateKey` (bucket C).

--- a/W1_SUMMARY.md
+++ b/W1_SUMMARY.md
@@ -1,9 +1,15 @@
-# W1 — WASM secret objects never freed or zeroized
+# W1 — WASM secret object lifecycle (delayed reclamation, not a leak)
 
-**Branch:** `fix/wasm-secret-lifecycle` (5 commits, not pushed)
+**Branch:** `fix/wasm-secret-lifecycle` (7 commits, all pushed — `af88ded`, `4a6cabb`,
+`991ce2d`, `d5337e1`, `06049de`, `3b1c1e1`, `d9b82ae`; `origin/fix/wasm-secret-lifecycle`
+now at `d9b82ae`, PR #324 open and shows all 7)
 **Base:** `main` @ `a441e75`
-**Status:** Phase 1 complete, gate cleared, Phase 2 complete, gauntlet green. Awaiting human review + device QA.
-**Not done (human gates):** no push, no PR, no merge, no tag, no release.
+**Status:** Phase 1 complete, gate cleared, Phase 2 complete, F1/F2 review fixes applied,
+gauntlet green (63 passed), QA build + harness served, device QA passed on both
+wallet-tag toggles (new-derivation and legacy), `d9b82ae` pushed and now on PR #324,
+CodeRabbit/Copilot review findings triaged and the real one fixed (not yet pushed —
+see §13).
+**Not done (human gates):** no merge, no tag, no release.
 
 ---
 
@@ -417,15 +423,243 @@ not a routine dependency update.
 
 ## 10. Constraints honored
 
-| Constraint                                | Status                                                                 |
-| ----------------------------------------- | ---------------------------------------------------------------------- |
-| Call-site changes only                    | ✅                                                                     |
-| No dependency change                      | ✅ G4, 0 lines                                                         |
-| No `wasm/` change                         | ✅ G5, 0 lines (and `assets/`, where the binary actually lives)        |
-| No `package*.json` change                 | ✅ G4                                                                  |
-| Both `isLegacy` branches covered          | ✅ every touched derivation site, both classes, tests at indexes 0/1/3 |
-| Shipped guards #306/#308/#310/#312 intact | ✅ G7                                                                  |
-| No `FinalizationRegistry` added           | ✅                                                                     |
-| Buckets B and D untouched                 | ✅                                                                     |
-| Tests as deliverable, not afterthought    | ✅ 21 new                                                              |
-| No push / PR / merge / tag / release      | ✅ none performed                                                      |
+| Constraint                                | Status                                                                                                                        |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Call-site changes only                    | ✅                                                                                                                            |
+| No dependency change                      | ✅ G4, 0 lines                                                                                                                |
+| No `wasm/` change                         | ✅ G5, 0 lines (and `assets/`, where the binary actually lives)                                                               |
+| No `package*.json` change                 | ✅ G4                                                                                                                         |
+| Both `isLegacy` branches covered          | ✅ every touched derivation site, both classes, tests at indexes 0/1/3                                                        |
+| Shipped guards #306/#308/#310/#312 intact | ✅ G7                                                                                                                         |
+| No `FinalizationRegistry` added           | ✅                                                                                                                            |
+| Buckets B and D untouched                 | ✅                                                                                                                            |
+| Tests as deliverable, not afterthought    | ✅ 21 new                                                                                                                     |
+| No push / PR / merge / tag / release      | ✅ none performed (as of Phase 1/2 — `d9b82ae` was pushed in the Round 2 follow-up; see §11. Merge/tag/release remain undone) |
+
+---
+
+## 11. Round 2 — F1/F2 review fixes, QA build + harness (2026-08-26)
+
+### F1 — `withOwned<T>` accepted async callbacks silently
+
+`lib/wallet/wasm-lifecycle.ts:32-` — the doc comment already warned "synchronous only,"
+but nothing enforced it. An async `fn` makes `T` infer `Promise<X>`, so owned objects
+were freed when the promise was _returned_, not when it resolved — a silent
+use-after-free on a still-live key, no compile error.
+
+Fix: after `fn(...)` returns, check whether the result is thenable
+(`typeof result.then === "function"`). If so, throw immediately naming the hazard,
+before the `finally` frees whatever was registered. Same reasoning as #310's sighash
+check living in `signTxInputWithScriptOption` rather than trusting call order — a doc
+comment is not a guard.
+
+Test added: `tests/signtx-unit.spec.ts:1368` — `"withOwned throws when the callback
+returns a thenable"` — passes an async arrow returning a resolved promise, asserts the
+throw and that the owned probe was still freed.
+
+### F2 — `catch {}` in the free loop swallowed wasm traps
+
+Same file, the `finally` loop's `try { object.free() } catch {}` discarded everything,
+including a genuine double-free trap. Changed to `catch (error) { console.error(...) }`
+— one failed free still can't block the rest of the loop or propagate into signing, but
+it's no longer invisible.
+
+### Gauntlet (re-run after F1/F2, direct binaries, exit codes captured to files
+
+outside any pipe, per the environment traps in the task brief)
+
+| Gate                                                                                                                                                             | Exit | Verified by                                                                                                                                                                                                                                 |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `./node_modules/.bin/tsc --noEmit`                                                                                                                               | 0    | `echo $? > file` after run, `cat`'d                                                                                                                                                                                                         |
+| `./node_modules/.bin/eslint .`                                                                                                                                   | 0    | same                                                                                                                                                                                                                                        |
+| `./node_modules/.bin/prettier --check .`                                                                                                                         | 0    | same; real prettier banner ("All matched files use Prettier code style!"), not the fabricated one                                                                                                                                           |
+| `./node_modules/.bin/playwright test tests/signtx-unit.spec.ts --reporter=line`                                                                                  | 0    | **62 passed** (61 prior + F1's new test), full reporter output inspected, not just exit code                                                                                                                                                |
+| `git diff main...HEAD -- package.json package-lock.json wasm/ assets/`                                                                                           | —    | empty (0 lines)                                                                                                                                                                                                                             |
+| `git diff main...HEAD -- lib/wallet/account/ledger-account.ts`                                                                                                   | —    | empty (0 lines)                                                                                                                                                                                                                             |
+| Guards byte-identical (`assertSafeOutputSighash`, `ALLOW_UNSAFE_OUTPUT_SIGHASH`, `hasScriptOptions`, `hasUnsignableFields`, `getDerivationFields`, `toSignType`) | —    | `lib/kaspa.ts` has zero diff vs main; `lib/wallet/sign-script.ts`'s 16-line diff touches only the private-key allocation site (now wrapped in `withOwned`), not the guard functions — confirmed by reading the full diff, not just the stat |
+
+`onboarding.spec.ts:7` not run — it's the known pre-existing failure on unmodified
+`main` in this environment, out of scope here (see §9.4).
+
+**Environment note:** `git status --short` fabricated a literal `ok` once when invoked
+as a plain `git` command (the `rtk` shim intercepts it per the Claude Code hook). All
+git/build/test commands in this round were run via absolute binary paths
+(`/opt/homebrew/bin/git`, `./node_modules/.bin/*`) with output redirected to files and
+exit codes read via `$?` outside any pipe, per the task's own environment-trap warning.
+
+Fixes committed as `d9b82ae` — `fix: withOwned rejects async callbacks, log swallowed
+free errors` (2 files, 40 insertions, 4 deletions). Pushed in the Round 2 follow-up
+below (`3b1c1e1..d9b82ae`, fast-forward) — see "Round 3 — push" section.
+
+### QA build
+
+- `npm run build` (node 20.20.2 via `nvm use 20`) → `.output/chrome-mv3/`
+- Post-build only, manifest edited on disk (source untouched):
+  - `name`: `Kastle (QA W1 d9b82ae)`
+  - `version_name`: `2.59.5-w1-qa-d9b82ae`
+  - Verified by reading `manifest.json` off disk after the edit, not from a build banner.
+- Copied to `~/Desktop/kastle-qa-w1/` — confirmed `~/Desktop/kastle-qa-w1/manifest.json`
+  exists and shows the QA name/version_name above.
+
+### QA harness
+
+- `~/Desktop/kastle-qa-w1/qa/index.html` — single self-contained file, no build step, no
+  external CDN, namespaced as `qa.*` (never `kastle`, per the prior harness collision).
+- API surface verified directly against `api/browser.ts` before writing any call —
+  `connect`, `getAccount`, `getVersion`, `signTx`, `signMessage`, `signAndBroadcastTx`,
+  `buildTransaction` (confirmed shape: `{networkId, transactions:[{txJson, id,
+feeAmount, changeAmount}]}`, not a string), and the generic `request(method, args)`
+  dispatcher (exact strings `"kas:sign_tx"` / `"kas:sign_and_broadcast_tx"` confirmed by
+  reading the dispatcher body, not guessed) — used for the Section 5 dApp-path tests to
+  exercise a genuinely different call convention than the direct methods in 1-4.
+- Section 0 splits into a safe read-only "Verify build" (`connect()` + `getAccount()` +
+  `getVersion()`, no signing prompt, manual checkbox naming the expected
+  `Kastle (QA W1 d9b82ae)` string) and a separate opt-in "Ledger sign-only probe" that
+  only ever signs a real transaction obtained via `buildTransaction()` — see Device QA
+  results below for why the original single-button design was replaced.
+- Sections 2 (repeat-use), 3 (lifecycle), 4 (real send, testnet-10), 5 (dApp path) all
+  implemented per the task's test list, each showing idle → running → ✅/❌ with the
+  actual error text on failure, plus a timestamped copyable log tagged by the
+  new-derivation/legacy wallet toggle.
+- Served: `cd ~/Desktop/kastle-qa-w1/qa && python3 -m http.server 8899`, confirmed
+  `HTTP 200` on `http://localhost:8899/` before handoff. Backgrounded.
+
+### Harness bugs found and fixed during live device QA
+
+Three bugs surfaced only once a real human ran the harness against the real extension —
+none of these touch the branch's actual source, all fixes are confined to
+`~/Desktop/kastle-qa-w1/qa/index.html`:
+
+1. **Popup crash on "Verify build".** Original Section 0 sent a hand-typed dummy
+   `"{}"` as `txJson` to `signTx()` as a behavioural probe. The popup tried to
+   deserialize it into a real `Transaction` before any sign-only gate could run, and
+   the deserialization error crashed the popup's own render — surfaced to the user as
+   `"Unexpected Application Error! Error processing JSON: missing field \`id\`..."`,
+uncatchable from the page since the popup runs in a separate window. Fixed by
+splitting Section 0 into a safe read-only verify and a separate opt-in Ledger probe
+that only ever signs a real, `buildTransaction()`-built tx.
+2. **"Host not connected" on every repeat-use/lifecycle test.** `buildTransaction()`
+   has no network input — it builds against whatever network the wallet's background
+   RPC client is actually connected to, and reports that network in the response. The
+   harness's self-send helper hardcoded `qa.NETWORK = "testnet-10"` for every
+   subsequent `signTx`/`request` call regardless of what the tx was actually built
+   against; a mismatch throws the wasm SDK's own RPC-connectivity error (confirmed by
+   grepping the string into `kaspa_bg.wasm` itself), which surfaces as a generic
+   connection failure with no mention of network. Fixed by having the self-send helper
+   return the tx's real `networkId` and threading that through every call site instead
+   of the hardcoded constant; added a `requireTestnet()` guard to the real-send and
+   dApp-broadcast tests so they refuse early and clearly if the wallet isn't actually
+   on testnet-10.
+3. **"Storage mass exceeds maximum" on every self-send.** The self-send amount was
+   1000 sompi (0.00001 KAS) — dust. Kaspa's KIP-9 storage-mass rule penalizes outputs
+   tiny relative to the spent input, and the mass formula blows up on dust-sized
+   outputs; consensus rejects it before signing is ever reached. Fixed by introducing
+   `qa.SELF_SEND_SOMPI = 100000000` (1 TKAS) as a single named constant and replacing
+   every hardcoded `1000`/`"1000"` occurrence with it.
+
+### Device QA results (2026-08-26, both wallet-tag toggles)
+
+Both toggles later ran clean end-to-end after the three fixes above. Transient early
+failures (`Insufficient funds`, `No UTXOs found for the address`,
+`Address network mismatch`) appear in the raw logs right after switching the
+extension's active network mid-run — expected settling noise while the wallet
+catches up to the new network, not regressions; every affected test passed on retry
+seconds later.
+
+| Wallet tag     | Connect | Repeat signTx 3x | Repeat signMessage 3x | Mixed 3x | Lock→unlock→sign | Sign after 60s idle | Real send (broadcast txid)                                                | dApp signAndBroadcastTx (txid)                                            | Repeat dApp sign 2x |
+| -------------- | ------- | ---------------- | --------------------- | -------- | ---------------- | ------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------------- |
+| new-derivation | PASS    | PASS             | PASS                  | PASS     | PASS             | PASS                | PASS (`91d7a7bea950c5c383ddbaed8f87d9caddb4879bcdab436494ce2983d74018cb`) | PASS (`859fc83c824eb138bb17879165e4660b050e990e55a1b1b16374996b852f7968`) | PASS                |
+| legacy         | PASS    | PASS             | PASS                  | PASS     | PASS (x2)        | PASS                | PASS (`22a0b6b6bf2475a6435f05d0eaf9500c02fc9cb3af791a4c9e14b2cde6e35b54`) | PASS (`7f358f17719506d6e57acefc81f16ffae85d93dac387c2e1cad0d6f311e27f44`) | PASS                |
+
+**Ledger sign-only probe:** PASS under both wallet tags once a Ledger account was
+actually selected as the active account in the extension (confirms the post-#308
+`"Ledger cannot complete sign-only requests yet..."` refusal string). Under the
+`legacy` tag, the first click returned `inconclusive: signed normally, no error` —
+at that point no Ledger account was active in the extension, so the call signed
+normally with the software key and never reached the refusal path; the harness
+correctly reports this as its own distinct outcome rather than a false PASS or FAIL.
+Ledger remains out of scope for source changes — `ledger-account.ts` is still a
+0-byte diff vs `main`; this probe only exercises the existing refusal path.
+
+### Handoff (see terminal output for the full checklist)
+
+1. `chrome://extensions` → Developer mode → Load unpacked → `~/Desktop/kastle-qa-w1/`
+2. Separate Chrome profile, exactly one Kastle enabled.
+3. Confirm card shows `Kastle (QA W1 d9b82ae)`.
+4. `http://localhost:8899/` → Verify build first.
+5. Sections 1-5 on new-derivation, then repeat on legacy.
+6. Ledger out of scope — `ledger-account.ts` is a 0-byte diff.
+
+## 12. Round 3 — push `d9b82ae` so PR #324 is complete (2026-08-26)
+
+`d9b82ae` (the F1/F2 fix) was committed in Round 2 but never pushed — PR #324 was
+missing the async-callback guard that was the entire point of F1. Confirmed the gap
+before touching anything: `origin/fix/wasm-secret-lifecycle` was at `3b1c1e1`, `HEAD`
+was `d9b82ae`, `git merge-base HEAD origin/fix/wasm-secret-lifecycle` equaled the
+origin tip (clean fast-forward, 0 behind / 1 ahead, no divergence), and
+`git branch -r --contains d9b82ae` was empty — not pushed anywhere.
+
+Gauntlet re-run on the current tree before pushing:
+
+| Gate                                                                            | Result                                                                                                                    |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `./node_modules/.bin/tsc --noEmit`                                              | exit 0                                                                                                                    |
+| `./node_modules/.bin/eslint .`                                                  | exit 0 (pre-existing warnings only, no errors)                                                                            |
+| `./node_modules/.bin/prettier --check .`                                        | exit 1 — sole offender was this file (`W1_SUMMARY.md`, uncommitted, mid-edit); reformatted below, not a source regression |
+| `./node_modules/.bin/playwright test tests/signtx-unit.spec.ts --reporter=line` | 62 passed, exit 0                                                                                                         |
+| `git diff main...HEAD -- package.json package-lock.json wasm/ assets/`          | empty                                                                                                                     |
+| `git diff main...HEAD -- lib/wallet/account/ledger-account.ts`                  | empty                                                                                                                     |
+
+Pushed: `git push origin fix/wasm-secret-lifecycle` → `3b1c1e1..d9b82ae`, fast-forward,
+exit 0. No `--force`, no rebase. Confirmed via `gh pr view 324` that PR #324 now lists
+all 7 commits with `d9b82ae` as the tip, and CI (`lint`, `build`, `e2e`) queued/running.
+Merge, tag, and release remain untouched — human-only, as scoped.
+
+## 13. Round 4 — CodeRabbit + Copilot review triage (2026-08-26)
+
+Pulled both bot reviews on PR #324 (`gh api repos/forbole/kastle/pulls/324/reviews` and
+`.../comments`). CodeRabbit and Copilot independently flagged the same real defect in
+`d9b82ae`'s own F1 fix — verified against the current code before touching anything,
+per their own "treat findings as untrusted, verify first" instruction:
+
+**Real bug, fixed:** the thenable guard threw, but the free loop lived in a `finally`,
+which runs on every exit path including a throw. So an async `fn` still had every
+object it had registered up to its first `await` freed immediately — the exact
+use-after-free F1 exists to catch, just now paired with a thrown error instead of
+silence, rather than prevented. Fixed by restructuring `withOwned` so the free pass
+never runs on the thenable-detected path at all: the callback is still suspended and
+may resume and use those objects later, so freeing there would corrupt a live object
+out from under it. Leaking on this path is the correct tradeoff — it can only happen on
+a code path that's supposed to never execute in real callers (an async `fn`), never on
+the normal synchronous one. Also switched the free order to LIFO (matches Rust's own
+reverse-declaration drop order for the objects this module wraps) per Copilot's
+suggestion — cheap, safe, and more correct for any future case where a derived object
+depends on the one it was derived from still being valid at free time.
+
+**Skipped, with reason:** CodeRabbit also suggested "strengthen the callback type or
+lint boundary to reject async/Promise-returning callbacks" as an alternative/addition
+to the runtime check. Left as runtime-only — the doc comment already commits to runtime
+enforcement as the design, a compile-time conditional-type trick on a generic return
+type is the kind of thing that tends to break inference at call sites in ways worse
+than the problem it solves, and the runtime throw already turns the misuse into an
+immediate, loud test failure. Revisit only if a real caller ever needs the type-level
+signal ahead of running the code.
+
+Added the regression test CodeRabbit asked for: an owned object registered, the
+callback awaits, and the object is used after the `await` — asserting it is not freed
+either at the moment `withOwned()` throws or after the suspended callback resumes and
+uses it.
+
+Gauntlet re-run after the fix:
+
+| Gate                                                                   | Result                                               |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| `tsc --noEmit`                                                         | exit 0                                               |
+| `eslint .`                                                             | exit 0                                               |
+| `prettier --check .`                                                   | exit 0                                               |
+| `playwright test tests/signtx-unit.spec.ts --reporter=line`            | **63 passed** (62 + the new regression test), exit 0 |
+| `git diff main...HEAD -- package.json package-lock.json wasm/ assets/` | empty                                                |
+| `git diff main...HEAD -- lib/wallet/account/ledger-account.ts`         | empty                                                |
+
+Files touched: `lib/wallet/wasm-lifecycle.ts`, `tests/signtx-unit.spec.ts`. Not yet
+committed or pushed — pending confirmation.

--- a/W1_SUMMARY.md
+++ b/W1_SUMMARY.md
@@ -1,0 +1,431 @@
+# W1 — WASM secret objects never freed or zeroized
+
+**Branch:** `fix/wasm-secret-lifecycle` (5 commits, not pushed)
+**Base:** `main` @ `a441e75`
+**Status:** Phase 1 complete, gate cleared, Phase 2 complete, gauntlet green. Awaiting human review + device QA.
+**Not done (human gates):** no push, no PR, no merge, no tag, no release.
+
+---
+
+## 0. TL;DR — and one correction to the brief
+
+The brief's premise #1 is **false as stated**. It says these objects are "never freed". They are
+freed — every secret-bearing class registers with a `FinalizationRegistry` on **both** allocation
+paths (`__wrap` and the constructor). This is not an unbounded leak; it is **delayed, nondeterministic
+reclamation**.
+
+That does not make the work pointless, but it does change the justification. The real problem is a
+**GC-visibility gap**: the JS heap object is a ~50-byte wrapper holding a pointer, while the
+allocation it owns lives in WASM linear memory where the JS GC has no visibility and feels no
+pressure. So the wrapper survives arbitrarily long, and with it the secret. `free()` at last use
+makes reclamation deterministic and bounds linear-memory growth.
+
+Severity is graded **Low-to-Medium**, below the brief's implied Medium. See §P1.4.
+
+**What this branch does:** every secret-bearing WASM object allocated in a scope that owns it is now
+freed at last use, on both `isLegacy` derivation branches, with 21 new tests pinning derived
+addresses so a branch swap cannot pass silently.
+
+**What this branch does NOT do:** it does not wipe key material from memory. See §7.
+
+---
+
+## 1. Phase 1 findings
+
+### P1.1 — Does `.free()` exist? Is there a `FinalizationRegistry`?
+
+Both yes. From `wasm/core/kaspa.js` (read-only, certified inventory):
+
+```js
+// :6948
+const PrivateKeyFinalization =
+  typeof FinalizationRegistry === "undefined"
+    ? { register: () => {}, unregister: () => {} }
+    : new FinalizationRegistry((ptr) =>
+        wasm.__wbg_privatekey_free(ptr >>> 0, 1),
+      );
+```
+
+| Class        | Finalization registry          | `free()` exposed |
+| ------------ | ------------------------------ | ---------------- |
+| `PrivateKey` | `PrivateKeyFinalization` :6948 | yes              |
+| `Keypair`    | `KeypairFinalization` :4675    | yes              |
+| `XPrv`       | `XPrvFinalization` :13498      | yes              |
+| `Mnemonic`   | `MnemonicFinalization` :4918   | yes              |
+
+Registration happens on **both** paths — `__wrap` at :6961 and the public constructor at :7098 — so
+no allocation route escapes it. Nothing is stranded forever; it is reclaimed _late_.
+
+**Ownership probe (this is what made freeing provably safe).** Before writing a single `.free()`, I
+checked the generated glue for every function these objects are passed to, looking for
+`_assertClass` (type-check = **borrow**) versus `__destroy_into_raw` (**consumes**):
+
+| Callee                       | `_assertClass` | `__destroy_into_raw` | Semantics                       |
+| ---------------------------- | -------------- | -------------------- | ------------------------------- |
+| `createInputSignature` L1122 | yes            | no                   | borrows                         |
+| `signTransaction` L1063      | yes            | no                   | borrows                         |
+| `signScriptHash` L1087       | yes            | no                   | borrows                         |
+| `signMessage` L1231          | —              | —                    | takes a `string`, not an object |
+
+No method consumes `this`. Derived objects are **independent allocations** (`XPrv.derivePath` →
+`XPrv.__wrap`, `toPrivateKey` → `PrivateKey.__wrap`, `toKeypair` → `Keypair.__wrap`, `toPublicKey`
+→ `PublicKey.__wrap`), so freeing a parent after deriving from it is safe. This is the fact the
+whole fix rests on; it was verified by reading the glue, not inferred.
+
+### P1.2 — Does the Rust side zeroize on drop?
+
+**No evidence of it, and the negative signal is strong.** Probing `assets/kaspa_bg.wasm`
+(11,817,646 bytes — note: the binary is under `assets/`, _not_ `wasm/core/`, which holds only
+`kaspa.d.ts` / `kaspa.js` / `kaspa_bg.wasm.d.ts`):
+
+| Symbol      | Occurrences |
+| ----------- | ----------- |
+| `zeroize`   | **0**       |
+| `Zeroizing` | **0**       |
+| `secp256k1` | 33          |
+| `bip32`     | 49          |
+| `panicked`  | 5           |
+| `unwrap`    | 92          |
+
+The control symbols prove the binary retains crate/symbol strings, so `zeroize` being absent is
+meaningful rather than an artifact of stripping. It is still not _proof_ — inlining and
+monomorphization can erase a name.
+
+**`BLOCKED: needs upstream confirmation`** from `@kcoin/kaspa-web3.js`. See §8.
+
+### P1.3 — Allocation-site inventory
+
+Buckets per the brief: **A** local scope (safe to free), **B** returned to caller (freeing at the
+alloc site is use-after-free), **C** stored on an instance (needs explicit lifecycle), **D**
+ambiguous (leave alone, list).
+
+| Site                                                    | Object                                    | Bucket | Action                                           |
+| ------------------------------------------------------- | ----------------------------------------- | ------ | ------------------------------------------------ |
+| `lib/wallet/sign-script.ts:205`                         | `PrivateKey` (**per input**)              | A      | **fixed**                                        |
+| `hot-wallet-account.ts` `getPrivateKeyString`           | `PrivateKey`, `Keypair`                   | A      | **fixed**                                        |
+| `hot-wallet-account.ts` `getPublicKeys` (legacy)        | `XPrv` + 3×50 derived                     | A      | **fixed**, freed per iteration                   |
+| `hot-wallet-account.ts` `getPublicKeys` (new)           | `XPrv`, `XPrv`, `PrivateKey`              | A      | **fixed**                                        |
+| `hot-wallet-account.ts` `getPrivateKeys` (both)         | `XPrv` + per-index derived                | A      | **fixed**, freed per iteration                   |
+| `hot-wallet-account.ts` `getPublicKey` (both)           | `PrivateKey` (intermediate)               | A      | **fixed** (returned `PublicKey` left to caller)  |
+| `hot-wallet-account.ts` `getPrivateKey` (both)          | `XPrv`, intermediate `XPrv`               | A      | **fixed** (returned `PrivateKey` left to caller) |
+| `lib/wallet/account-factory.ts` `generateMnemonic` ×2   | `Mnemonic`                                | A      | **fixed**                                        |
+| `lib/wallet/account-factory.ts` `createFromMnemonic` ×2 | `Mnemonic`                                | A      | **fixed**                                        |
+| `lib/ethereum/wallet/account-factory.ts` ×2             | `Mnemonic`, `XPrv`, derived, `PrivateKey` | A      | **fixed**, both `isLegacy` branches in one scope |
+| `ImportPrivateKey.tsx:99`                               | `PrivateKey` (validation only)            | A      | **fixed**                                        |
+| `ImportRecoveryPhrase.tsx:110`                          | `Mnemonic` (validation only)              | A      | **fixed**                                        |
+| `ImportRecoveryPhraseWithPassphrase.tsx:33`             | `Mnemonic` (validation only)              | A      | **fixed**                                        |
+| `hot-wallet-account.ts` `getPrivateKey` return value    | `PrivateKey`                              | **B**  | **not touched** — caller owns it                 |
+| `hot-wallet-account.ts` `getPublicKey` return value     | `PublicKey`                               | **B**  | **not touched** — caller owns it                 |
+| `account-factory.ts` `createFromPrivateKey` ×2          | `PrivateKey` → `HotWalletPrivateKey`      | **C**  | **not touched** — see below                      |
+| `hot-wallet-private-key.ts:16`                          | `PrivateKey` held as a field              | **C**  | **not touched** — see below                      |
+
+**Why bucket C was left alone.** `HotWalletPrivateKey` holds a `PrivateKey` for the object's entire
+life and has no disposal hook, no `destroy()`, and no caller that knows when the account is done.
+Freeing it needs a lifecycle contract that does not exist yet, and inventing one would mean touching
+the wallet-teardown path — well outside "call-site changes only", and squarely in the 🔴 signing
+blast radius. Listed, not guessed. This is the main follow-up.
+
+The three validation-only import sites deserve a note: those effects re-run **on every keystroke**,
+so they were allocating a fresh `Mnemonic`/`PrivateKey` per character typed. Small objects, but the
+highest _allocation rate_ in the codebase.
+
+### P1.4 — Exposure assessment: **Low-to-Medium**
+
+Below the brief's implied Medium. Reasoning, stated so it can be argued with:
+
+- **Down:** the `FinalizationRegistry` exists (§P1.1), so this is delayed reclamation, not
+  permanent retention.
+- **Down:** MV3 service-worker teardown hard-bounds the background instance's lifetime — the whole
+  linear memory dies on reclaim, typically within ~30s idle.
+- **Down:** exploiting this requires **code execution in the extension's own context**. An attacker
+  who has that can read the decrypted mnemonic out of the wallet state directly and does not need to
+  scrape linear memory.
+- **Up:** WASM linear memory is a plain JS-readable `ArrayBuffer` — no privilege boundary at all.
+- **Up, and larger than the WASM surface:** `toSeed()`, `Keypair.privateKey`, `XPrv.privateKey` and
+  `PrivateKey.toString()` all return **plain immutable JS strings**. `LegacyHotWalletAccount` holds
+  the master seed as `protected readonly seed: string` for its entire lifetime. Immutable strings
+  cannot be zeroed at all, in any language runtime, ever.
+
+**That last point matters more than everything this branch fixes.** The plaintext-string surface is
+strictly larger and strictly harder to remediate than the WASM-object surface, and Phase 2 does not
+address it. Anyone reading this summary as "the memory-exposure issue is handled" has misread it.
+
+### P1.5 — Test strategy
+
+Constraint discovered while writing tests: **Kaspa schnorr message signing uses aux randomness**, so
+the same key produces a different signature every run. Signatures cannot be pinned as fixtures.
+Tests therefore assert on **derived addresses and public keys** (deterministic) and check signatures
+**structurally** (present, correct length, verifies).
+
+Second constraint, and the one that actually guards the landmine: **at `accountIndex` 0 the two
+derivation paths coincide.**
+
+```
+legacy: m/44'/111111'/{accountIndex}'/0/{index}
+new:    m/44'/111111'/0'/0/{accountIndex}
+```
+
+At index 0 both reduce to `m/44'/111111'/0'/0/0`. A test that only covers index 0 will pass happily
+through a branch swap. Vectors were therefore captured at **indexes 0, 1 and 3**, generated
+programmatically from the unmodified code rather than transcribed by hand.
+
+| Branch / index | Address (truncated)             |
+| -------------- | ------------------------------- |
+| legacy 0       | `kaspa:qqd6e65yefepe9wk0m9vux…` |
+| new 0          | _identical_ — this is the trap  |
+| legacy 1       | `kaspa:qzyqe0y64jqvx043jd0mpg…` |
+| new 1          | `kaspa:qp6r0d88yj4fazlj057wc3…` |
+| legacy 3       | `kaspa:qrgg2k6l7r96x8ckw64rnc…` |
+| new 3          | `kaspa:qqwn552u0tdqgcggarzeh2…` |
+
+Mnemonic: `abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about`.
+
+---
+
+## 2. GATE decision
+
+| Gate condition                                             | Result                                                        |
+| ---------------------------------------------------------- | ------------------------------------------------------------- |
+| `.free()` confirmed available                              | ✅ all four classes                                           |
+| Bucket (A) non-trivial                                     | ✅ 13 sites, incl. a per-input allocation on the signing path |
+| Test proving signing works on **both** `isLegacy` branches | ✅ 21 tests, vectors at indexes 0/1/3                         |
+
+**Gate cleared → proceeded to Phase 2.**
+
+---
+
+## 3. What changed
+
+```
+06049de test: cover WASM secret lifecycle on both derivation branches
+af88ded fix: free validation-only WASM secret objects in the import screens
+4a6cabb fix: free Mnemonic and XPrv temporaries in the account factories
+991ce2d fix: free WASM secret objects in hot wallet derivation
+d5337e1 fix: free the per-input PrivateKey on the signing path
+```
+
+```
+ components/screens/full-pages/ImportPrivateKey.tsx                  |   6 +-
+ components/screens/full-pages/ImportRecoveryPhrase.tsx              |   6 +-
+ components/screens/full-pages/ImportRecoveryPhraseWithPassphrase.tsx|   6 +-
+ lib/ethereum/wallet/account-factory.ts                              |  36 ++--
+ lib/wallet/account-factory.ts                                       |  15 +-
+ lib/wallet/account/hot-wallet-account.ts                            | 117 +++++++-----
+ lib/wallet/sign-script.ts                                           |  16 +-
+ lib/wallet/wasm-lifecycle.ts                                        |  52 ++++++
+ tests/signtx-unit.spec.ts                                           | 203 +++++++++++++++++++++
+ 9 files changed, 388 insertions(+), 69 deletions(-)
+```
+
+One new file, `lib/wallet/wasm-lifecycle.ts` (52 lines), exporting a single scope guard:
+
+```ts
+export function withOwned<T>(
+  fn: (own: <O extends Freeable>(o: O) => O) => T,
+): T;
+```
+
+Register at the point of creation — `own(new XPrv(seed))` — and everything registered is freed when
+the scope returns _or throws_. Chosen over hand-written nested `try/finally` because the deepest site
+nests three objects and hand-rolled unwinding at three levels is where use-after-free bugs come from.
+It is **synchronous only** — with an async `fn` the `finally` would fire at the first `await` and
+free objects still in use. Every current caller is sync; the doc comment says so.
+
+Per the brief: **no `FinalizationRegistry` was added** (one already exists upstream anyway).
+
+---
+
+## 4. Gauntlet receipts
+
+| #   | Check                                                    | Result                                                       |
+| --- | -------------------------------------------------------- | ------------------------------------------------------------ |
+| G1  | `npm run compile`                                        | ✅ exit 0, 0 errors                                          |
+| G2  | lint / prettier                                          | ✅ eslint exit 0 · prettier exit 0                           |
+| G3  | `playwright test tests/signtx-unit.spec.ts`              | ✅ **61 passed** (40 baseline + 21 new)                      |
+| G4  | `git diff main...HEAD -- package.json package-lock.json` | ✅ **0 lines**                                               |
+| G5  | `git diff main...HEAD -- wasm/ assets/`                  | ✅ **0 lines**                                               |
+| G6  | ⚠️ both `isLegacy` branches unchanged                    | ✅ pinned vectors at indexes 0/1/3                           |
+| G7  | shipped guards intact                                    | ✅ see below                                                 |
+| G8  | `npm run e2e`                                            | ✅ 61 passed, 1 failure — **pre-existing, proven on `main`** |
+
+**G2 note.** `npm run prettier` returns a bogus exit and the `rtk` shim prints a fabricated
+"All files formatted correctly" banner regardless of the true result. Both tools were therefore run
+via their **direct binary paths** (`./node_modules/.bin/…`) and the exit codes taken as
+authoritative. Doing this caught a genuine prettier failure the fake banner had hidden — it was
+`W1_INVESTIGATION.md`, an untracked deliverable, not a source file; formatted, now exit 0. eslint's
+baseline `no-unused-vars` warnings across ~33 unrelated files are unchanged, and 0 hits land on any
+file this branch touches.
+
+**G7 — shipped guards, all verified present and unmodified:**
+
+| PR   | Guard                                                                                   | Location                                          |
+| ---- | --------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| #306 | `assertSafeOutputSighash`, `ALLOW_UNSAFE_OUTPUT_SIGHASH`, `toSignType` `hasOwnProperty` | `lib/wallet/sign-script.ts`                       |
+| #308 | `hasScriptOptions` + sign-only refusal                                                  | `lib/wallet/sign-script.ts`, `LedgerSignTx.tsx`   |
+| #310 | `hasUnsignableFields`, `LEDGER_UNSIGNABLE_FIELDS_MESSAGE`                               | `sign-script.ts`, `LedgerSignAndBroadcast.tsx:24` |
+| #312 | `getDerivationFields`                                                                   | untouched                                         |
+
+The only edit inside `sign-script.ts` is the L205 allocation; the diff is `-6,6 +6,7` (one import) and
+`-198,11 +199,16` (the wrapped call). Every guard function is byte-identical to `main`.
+
+**G8 — the one e2e failure.** `onboarding.spec.ts:7`, _"Test timeout of 30000ms exceeded while
+setting up context"_. Re-ran once per the brief — failed again. Then checked out `main` (`a441e75`)
+and ran it there: **fails identically**. This is a pre-existing environment failure, not a
+regression from this branch.
+
+Worth flagging honestly: the brief states this spec "has passed on recent runs". In this environment
+it does not pass on `main` either, so either the environment differs or that note is stale.
+
+---
+
+## 5. QA build
+
+`wxt.config.ts` was temporarily marked, built, verified, and reverted:
+
+```
+Kastle [W1 QA] | 2.59.5 | 2.59.5-w1-wasm-secret-lifecycle
+```
+
+`npm run build` exit 0. Marker reverted afterwards — the working tree carries **0 modified tracked
+files**; `.output/chrome-mv3/` retains the marking. Load **that** directory, and confirm the manifest
+shows `Kastle [W1 QA]` before trusting a single QA result.
+
+### Build-fingerprint probe — with a correction
+
+The brief prescribes: a script-free sign-only `signTx` returns _"cannot complete sign-only requests"_
+on post-#308 builds, versus _"advanced scripts signing"_ / _"Method not implemented."_ on pre-#308.
+The **behavioral** probe is correct and is the check to run in the field.
+
+But the **static string grep is not a valid staleness test**, and I want that written down before it
+misleads someone. `LedgerSignTx.tsx:28-29` is a single ternary:
+
+```
+? "…does not support advanced scripts signing"
+: "…cannot complete sign-only requests yet…"
+```
+
+Both strings ship in the same post-#308 file, on the two branches of one conditional. Finding
+`"advanced scripts signing"` in a bundle therefore proves **nothing** about staleness. Results on
+this build:
+
+| Marker                               | Present                       | Meaning                                                  |
+| ------------------------------------ | ----------------------------- | -------------------------------------------------------- |
+| `cannot complete sign-only requests` | ✅ `chunks/popup-Ccun89nk.js` | **post-#308 confirmed** — this is the only discriminator |
+| `advanced scripts signing`           | ✅ same file                  | expected; the other ternary branch, not a signal         |
+| `Method not implemented`             | ❌ absent                     | —                                                        |
+
+The `:` branch is what #308 added, so its presence is the discriminator. The "script-free" qualifier
+in the brief is exactly what selects that branch at runtime. **This build is post-#308.**
+
+---
+
+## 6. Manual QA checklist
+
+Load `.output/chrome-mv3`. Confirm the manifest reads `Kastle [W1 QA] / 2.59.5-w1-wasm-secret-lifecycle`
+first — a stale build silently answered an entire QA run once before, and version strings collide.
+
+One extension per Chrome profile: two Kastle builds in one profile race to inject `window.kastle`.
+
+| #   | Check                                            | Expected                                                     |
+| --- | ------------------------------------------------ | ------------------------------------------------------------ |
+| 1   | **Send on a new-derivation wallet**              | correct address derived, tx broadcasts, confirms             |
+| 2   | **Send on a legacy wallet** ⚠️                   | correct address derived, tx broadcasts, confirms             |
+| 3   | **Sign a message — new-derivation**              | signature produced and verifies                              |
+| 4   | **Sign a message — legacy** ⚠️                   | signature produced and verifies                              |
+| 5   | **Lock / unlock**                                | wallet re-derives, addresses **identical** to before locking |
+| 6   | **dApp `signAndBroadcastTx`**                    | full round trip succeeds                                     |
+| 7   | Import recovery phrase (type slowly, ~20+ chars) | validation still live per keystroke, no lag, no crash        |
+| 8   | Import private key                               | validation still live, import succeeds                       |
+| 9   | Account list with many addresses                 | all 50 legacy addresses render, unchanged                    |
+| 10  | Ethereum account, both branches ⚠️               | addresses unchanged                                          |
+
+⚠️ = touches the `isLegacy` landmine. **Rows 1–6 must be run on both wallet types**; a fix that works
+on one branch and breaks the other is a wrong-key-signs bug, and rows 2/4/10 are the ones that catch it.
+
+For rows 1–4, the highest-value check is simply: **is the derived address the same one that wallet
+showed before this build?** If any address moved, stop.
+
+---
+
+## 7. Honest statement — what this does and does not achieve
+
+**Achieved:**
+
+- WASM secret objects in scopes that own them are freed **deterministically at last use** instead of
+  waiting on GC that has no reason to run. Linear-memory growth from repeated signing, key derivation
+  and keystroke-driven validation is bounded.
+- The per-input `PrivateKey` on the signing path is freed per input rather than accumulating across a
+  multi-input transaction.
+- Freeing was proven safe by reading the wasm-bindgen glue — all callees borrow, none consume — not
+  assumed.
+- Both derivation branches are now pinned by tests at indexes where they actually differ.
+
+**Not achieved — and this is the part that must not be glossed:**
+
+- **Keys are not wiped from memory.** `free()` returns the allocation to the WASM allocator; it does
+  **not** zero the bytes. The secret stays readable in linear memory until the allocator happens to
+  reuse that region — which may be never. Freeing fixes reclamation outright and helps exposure only
+  _probabilistically_.
+- **Do not describe this work as "keys are now wiped from memory."** It is not what happened.
+- The real fix for exposure is `zeroize` / `ZeroizeOnDrop` on the Rust side, upstream. It cannot be
+  done from call sites, and this branch is call-sites-only by constraint.
+- **The plaintext JS-string surface is untouched and is larger than what was fixed** (§P1.4).
+  `LegacyHotWalletAccount` holds the master seed as a `protected readonly seed: string` for its whole
+  life. Immutable JS strings cannot be zeroed. This is unaddressed and is arguably the more important
+  finding of the whole investigation.
+- Bucket **C** (`HotWalletPrivateKey`'s instance-held `PrivateKey`) is unaddressed pending a
+  lifecycle contract.
+
+A fair one-line characterization: _reclamation is now prompt and deterministic; exposure is reduced
+but not eliminated, and the largest exposure surface is out of scope._
+
+---
+
+## 8. Upstream question for `@kcoin/kaspa-web3.js`
+
+To raise with the maintainers — this is the actual fix for exposure:
+
+> Do the secret-bearing types (`PrivateKey`, `Keypair`, `XPrv`, `Mnemonic`) zeroize their key
+> material on drop?
+>
+> We can find no `zeroize` or `Zeroizing` symbols in the shipped `kaspa_bg.wasm`, while control
+> symbols (`secp256k1`, `bip32`, `panicked`) are retained — so the absence looks meaningful rather
+> than stripped, though inlining could explain it. Calling `free()` from JS deallocates but leaves
+> the bytes readable in linear memory, which any script in the page can read as an `ArrayBuffer`.
+>
+> 1. Is `ZeroizeOnDrop` (or an equivalent manual wipe) applied to these types today?
+> 2. If not, would you accept a PR adding it?
+> 3. Separately: `toSeed()`, `Keypair.privateKey`, `XPrv.privateKey` and `PrivateKey.toString()`
+>    return plain JS strings, which are immutable and can never be zeroed by the consumer. Is there
+>    an API that keeps the secret WASM-side, or could one be added?
+
+Question 3 is the one that matters most for us. Note that `@kcoin/kaspa-web3.js` and the WASM binary
+are certified crypto inventory (audited 2026-07-29) — any upstream bump is a re-certification event,
+not a routine dependency update.
+
+---
+
+## 9. Follow-ups (not in this branch)
+
+1. **Upstream `ZeroizeOnDrop`** — §8. The only real fix for exposure.
+2. **Bucket C lifecycle** — give `HotWalletPrivateKey` a disposal contract, then free its field.
+3. **The JS-string seed surface** — depends on upstream question 3. Largest remaining exposure.
+4. **`onboarding.spec.ts:7`** — fails on `main` in this environment; the brief believes it passes.
+   Worth reconciling separately from this work.
+
+---
+
+## 10. Constraints honored
+
+| Constraint                                | Status                                                                 |
+| ----------------------------------------- | ---------------------------------------------------------------------- |
+| Call-site changes only                    | ✅                                                                     |
+| No dependency change                      | ✅ G4, 0 lines                                                         |
+| No `wasm/` change                         | ✅ G5, 0 lines (and `assets/`, where the binary actually lives)        |
+| No `package*.json` change                 | ✅ G4                                                                  |
+| Both `isLegacy` branches covered          | ✅ every touched derivation site, both classes, tests at indexes 0/1/3 |
+| Shipped guards #306/#308/#310/#312 intact | ✅ G7                                                                  |
+| No `FinalizationRegistry` added           | ✅                                                                     |
+| Buckets B and D untouched                 | ✅                                                                     |
+| Tests as deliverable, not afterthought    | ✅ 21 new                                                              |
+| No push / PR / merge / tag / release      | ✅ none performed                                                      |

--- a/components/screens/full-pages/ImportPrivateKey.tsx
+++ b/components/screens/full-pages/ImportPrivateKey.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { v4 as uuid } from "uuid";
 import useAnalytics from "@/hooks/useAnalytics.ts";
 import { PrivateKey } from "@/wasm/core/kaspa";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 import { useBoolean } from "usehooks-ts";
 import { OnboardingData } from "@/components/screens/Onboarding.tsx";
 import Header from "@/components/GeneralHeader.tsx";
@@ -96,7 +97,10 @@ export default function ImportPrivateKey() {
                   required: "Private key is required",
                   validate: (privateKey) => {
                     try {
-                      new PrivateKey(privateKey);
+                      // validation only — the key object is dead immediately
+                      withOwned((own) => {
+                        own(new PrivateKey(privateKey));
+                      });
                       // eslint-disable-next-line @typescript-eslint/no-unused-vars
                     } catch (_) {
                       return "Oh, the private key is invalid";

--- a/components/screens/full-pages/ImportRecoveryPhrase.tsx
+++ b/components/screens/full-pages/ImportRecoveryPhrase.tsx
@@ -5,6 +5,7 @@ import { twMerge } from "tailwind-merge";
 import { v4 as uuid } from "uuid";
 import useAnalytics from "@/hooks/useAnalytics.ts";
 import { Mnemonic } from "@/wasm/core/kaspa";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 import { useBoolean } from "usehooks-ts";
 import { OnboardingData } from "@/components/screens/Onboarding.tsx";
 import useKeyring from "@/hooks/useKeyring.ts";
@@ -107,7 +108,10 @@ export default function ImportRecoveryPhrase() {
 
   useEffect(() => {
     try {
-      new Mnemonic(joinRecoveryPhrase());
+      // validation only, and this effect re-runs on every keystroke
+      withOwned((own) => {
+        own(new Mnemonic(joinRecoveryPhrase()));
+      });
 
       setRecoveryPhraseError(undefined);
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/components/screens/full-pages/ImportRecoveryPhraseWithPassphrase.tsx
+++ b/components/screens/full-pages/ImportRecoveryPhraseWithPassphrase.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useFormContext } from "react-hook-form";
 import { v4 as uuid } from "uuid";
 import { Mnemonic } from "@/wasm/core/kaspa";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 import { OnboardingData } from "@/components/screens/Onboarding.tsx";
 import useKeyring from "@/hooks/useKeyring.ts";
 import useAnalytics from "@/hooks/useAnalytics.ts";
@@ -30,7 +31,10 @@ export default function ImportRecoveryPhraseWithPassphrase() {
   const handlePhraseSubmit = (words: string[]) => {
     const joined = words.join(" ");
     try {
-      new Mnemonic(joined);
+      // validation only — the mnemonic object is dead immediately
+      withOwned((own) => {
+        own(new Mnemonic(joined));
+      });
     } catch {
       setPhraseError("The recovery phrase is invalid. Please check it.");
       return;

--- a/lib/ethereum/wallet/account-factory.ts
+++ b/lib/ethereum/wallet/account-factory.ts
@@ -1,6 +1,7 @@
 import { EthereumPrivateKeyAccount } from "./account/private-key-account";
 import { Mnemonic } from "@/wasm/core/kaspa";
 import { XPrv } from "@/wasm/core/kaspa";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 
 export class LegacyAccountFactory {
   createFromMnemonic(
@@ -9,15 +10,18 @@ export class LegacyAccountFactory {
     isKastleLegacy = false,
     passphrase?: string,
   ): EthereumPrivateKeyAccount {
-    const seed = new Mnemonic(mnemonic).toSeed(passphrase);
-    const xprv = new XPrv(seed);
-    const path = isKastleLegacy
-      ? `m/44'/111111'/${accountIndex}'/0/0`
-      : `m/44'/111111'/0'/0/${accountIndex}`;
+    // both derivation branches allocate identically, so one scope covers each
+    const privateKey = withOwned((own) => {
+      const seed = own(new Mnemonic(mnemonic)).toSeed(passphrase);
+      const xprv = own(new XPrv(seed));
+      const path = isKastleLegacy
+        ? `m/44'/111111'/${accountIndex}'/0/0`
+        : `m/44'/111111'/0'/0/${accountIndex}`;
 
-    const privateKey = xprv.derivePath(path).toPrivateKey();
+      return own(own(xprv.derivePath(path)).toPrivateKey()).toString();
+    });
 
-    return new EthereumPrivateKeyAccount(privateKey.toString());
+    return new EthereumPrivateKeyAccount(privateKey);
   }
 
   createFromPrivateKey(privateKey: string): EthereumPrivateKeyAccount {
@@ -32,13 +36,17 @@ export class AccountFactory extends LegacyAccountFactory {
     isKastleLegacy = false,
     passphrase?: string,
   ): EthereumPrivateKeyAccount {
-    const seed = new Mnemonic(mnemonic).toSeed(passphrase);
-    const xprv = new XPrv(seed);
-    const path = isKastleLegacy
-      ? `m/44'/60'/${accountIndex}'/0/0`
-      : `m/44'/60'/0'/0/${accountIndex}`;
+    // both derivation branches allocate identically, so one scope covers each
+    const privateKey = withOwned((own) => {
+      const seed = own(new Mnemonic(mnemonic)).toSeed(passphrase);
+      const xprv = own(new XPrv(seed));
+      const path = isKastleLegacy
+        ? `m/44'/60'/${accountIndex}'/0/0`
+        : `m/44'/60'/0'/0/${accountIndex}`;
 
-    const privateKey = xprv.derivePath(path).toPrivateKey();
-    return new EthereumPrivateKeyAccount(privateKey.toString());
+      return own(own(xprv.derivePath(path)).toPrivateKey()).toString();
+    });
+
+    return new EthereumPrivateKeyAccount(privateKey);
   }
 }

--- a/lib/wallet/account-factory.ts
+++ b/lib/wallet/account-factory.ts
@@ -10,10 +10,11 @@ import {
   LedgerAccount,
 } from "@/lib/wallet/account/ledger-account.ts";
 import Transport from "@ledgerhq/hw-transport";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 
 export class LegacyAccountFactory {
   static generateMnemonic(): string {
-    return Mnemonic.random(12).phrase;
+    return withOwned((own) => own(Mnemonic.random(12)).phrase);
   }
 
   createFromLedger(transport: Transport, accountIndex: number = 0): IWallet {
@@ -25,7 +26,10 @@ export class LegacyAccountFactory {
     accountIndex: number = 0,
     passphrase?: string,
   ): IWallet {
-    const seed = new Mnemonic(mnemonic).toSeed(passphrase);
+    // `.toSeed()` returns a plain JS string, so the Mnemonic is dead here
+    const seed = withOwned((own) =>
+      own(new Mnemonic(mnemonic)).toSeed(passphrase),
+    );
 
     return new LegacyHotWalletAccount(seed, accountIndex);
   }
@@ -39,7 +43,7 @@ export class AccountFactory {
   constructor() {}
 
   static generateMnemonic(): string {
-    return Mnemonic.random(12).phrase;
+    return withOwned((own) => own(Mnemonic.random(12)).phrase);
   }
 
   createFromLedger(transport: Transport, accountIndex: number = 0): IWallet {
@@ -51,7 +55,10 @@ export class AccountFactory {
     accountIndex: number = 0,
     passphrase?: string,
   ): IWallet {
-    const seed = new Mnemonic(mnemonic).toSeed(passphrase);
+    // `.toSeed()` returns a plain JS string, so the Mnemonic is dead here
+    const seed = withOwned((own) =>
+      own(new Mnemonic(mnemonic)).toSeed(passphrase),
+    );
 
     return new HotWalletAccount(seed, accountIndex);
   }

--- a/lib/wallet/account/hot-wallet-account.ts
+++ b/lib/wallet/account/hot-wallet-account.ts
@@ -2,6 +2,7 @@ import { PublicKey, Transaction, XPrv, signMessage } from "@/wasm/core/kaspa";
 
 import { IWallet, ScriptOption } from "@/lib/wallet/wallet-interface.ts";
 import { signTxWithScriptOptions } from "@/lib/wallet/sign-script.ts";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 
 export class LegacyHotWalletAccount implements IWallet {
   private readonly MAX_DERIVATION_INDEXES = 50;
@@ -12,24 +13,35 @@ export class LegacyHotWalletAccount implements IWallet {
   ) {}
 
   public getPrivateKeyString() {
-    const privateKey = this.getPrivateKey();
-    return privateKey.toKeypair().privateKey;
+    // getPrivateKey hands ownership to us, and `.privateKey` is a plain JS
+    // string, so nothing WASM-side outlives this call
+    return withOwned(
+      (own) => own(own(this.getPrivateKey()).toKeypair()).privateKey,
+    );
   }
 
   public getPublicKeys() {
-    const xprv = new XPrv(this.seed);
+    return withOwned((own) => {
+      const xprv = own(new XPrv(this.seed));
+      const publicKeys: string[] = [];
 
-    const publicKeys: string[] = [];
+      for (let index = 0; index < this.MAX_DERIVATION_INDEXES; index++) {
+        // free per iteration: one scope around the whole loop would hold 150
+        // live WASM objects at peak
+        publicKeys.push(
+          withOwned((ownIndex) => {
+            const derived = ownIndex(
+              xprv.derivePath(`m/44'/111111'/${this.accountIndex}'/0/${index}`),
+            );
+            const privateKey = ownIndex(derived.toPrivateKey());
 
-    for (let index = 0; index < this.MAX_DERIVATION_INDEXES; index++) {
-      const privateKey = xprv
-        .derivePath(`m/44'/111111'/${this.accountIndex}'/0/${index}`)
-        .toPrivateKey();
+            return ownIndex(privateKey.toPublicKey()).toString();
+          }),
+        );
+      }
 
-      publicKeys.push(privateKey.toPublicKey().toString());
-    }
-
-    return publicKeys;
+      return publicKeys;
+    });
   }
 
   // NOTE: This method does not support signing with multiple keys
@@ -38,7 +50,9 @@ export class LegacyHotWalletAccount implements IWallet {
   }
 
   getPublicKey(): PublicKey {
-    return this.getPrivateKey().toPublicKey();
+    // the PublicKey is returned, so it belongs to the caller — only the
+    // PrivateKey is ours to free
+    return withOwned((own) => own(this.getPrivateKey()).toPublicKey());
   }
 
   signMessage(message: string): string {
@@ -46,25 +60,32 @@ export class LegacyHotWalletAccount implements IWallet {
   }
 
   protected getPrivateKey() {
-    const xprv = new XPrv(this.seed);
-    return xprv
-      .derivePath(`m/44'/111111'/${this.accountIndex}'/0/0`)
-      .toPrivateKey();
+    // the PrivateKey is returned to the caller, who owns it; the XPrv and the
+    // intermediate derivation are ours
+    return withOwned((own) =>
+      own(
+        own(new XPrv(this.seed)).derivePath(
+          `m/44'/111111'/${this.accountIndex}'/0/0`,
+        ),
+      ).toPrivateKey(),
+    );
   }
 
   protected getPrivateKeys(indexes: number[]) {
-    const xprv = new XPrv(this.seed);
-    const privateKeys = [];
+    return withOwned((own) => {
+      const xprv = own(new XPrv(this.seed));
 
-    for (const index of indexes) {
-      const address = xprv
-        .derivePath(`m/44'/111111'/${this.accountIndex}'/0/${index}`)
-        .toPrivateKey();
+      return indexes.map((index) =>
+        withOwned((ownIndex) => {
+          const derived = ownIndex(
+            xprv.derivePath(`m/44'/111111'/${this.accountIndex}'/0/${index}`),
+          );
 
-      privateKeys.push(address.toKeypair().privateKey);
-    }
-
-    return privateKeys;
+          return ownIndex(ownIndex(derived.toPrivateKey()).toKeypair())
+            .privateKey;
+        }),
+      );
+    });
   }
 }
 
@@ -74,22 +95,32 @@ export class HotWalletAccount extends LegacyHotWalletAccount {
   }
 
   override getPublicKeys() {
-    const xprv = new XPrv(this.seed);
-    const privateKey = xprv
-      .derivePath(`m/44'/111111'/0'/0/${this.accountIndex}`)
-      .toPrivateKey();
+    return withOwned((own) => {
+      const derived = own(
+        own(new XPrv(this.seed)).derivePath(
+          `m/44'/111111'/0'/0/${this.accountIndex}`,
+        ),
+      );
+      const privateKey = own(derived.toPrivateKey());
 
-    return [privateKey.toPublicKey().toString()];
+      return [own(privateKey.toPublicKey()).toString()];
+    });
   }
 
   override getPrivateKey() {
-    const xprv = new XPrv(this.seed);
-    return xprv
-      .derivePath(`m/44'/111111'/0'/0/${this.accountIndex}`)
-      .toPrivateKey();
+    // as above: the returned PrivateKey is the caller's
+    return withOwned((own) =>
+      own(
+        own(new XPrv(this.seed)).derivePath(
+          `m/44'/111111'/0'/0/${this.accountIndex}`,
+        ),
+      ).toPrivateKey(),
+    );
   }
 
   override getPrivateKeys(indexes: number[]) {
-    return [this.getPrivateKey().toKeypair().privateKey];
+    return withOwned((own) => [
+      own(own(this.getPrivateKey()).toKeypair()).privateKey,
+    ]);
   }
 }

--- a/lib/wallet/sign-script.ts
+++ b/lib/wallet/sign-script.ts
@@ -6,6 +6,7 @@ import {
 } from "@/wasm/core/kaspa";
 import { ScriptOption } from "@/lib/wallet/wallet-interface.ts";
 import { toSignType } from "@/lib/kaspa.ts";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle.ts";
 
 // dApps send the documented `scriptHex`, but some send `script` instead —
 // accept both. Arrays may also be sparse (holes / null entries).
@@ -198,11 +199,16 @@ export function signTxInputWithScriptOption(
     );
   }
 
-  const signature = createInputSignature(
-    tx,
-    option.inputIndex,
-    new PrivateKey(privateKeyString),
-    toSignType(option.signType ?? "All"),
+  // called once per input, so this allocation is per-input too.
+  // createInputSignature borrows the key (the wasm-bindgen glue type-checks it
+  // but never takes ownership), so freeing it here is safe.
+  const signature = withOwned((own) =>
+    createInputSignature(
+      tx,
+      option.inputIndex,
+      own(new PrivateKey(privateKeyString)),
+      toSignType(option.signType ?? "All"),
+    ),
   );
 
   // `signature` is already a push-encoded script element; for P2SH append

--- a/lib/wallet/wasm-lifecycle.ts
+++ b/lib/wallet/wasm-lifecycle.ts
@@ -27,7 +27,9 @@ type Freeable = { free: () => void };
  * the scope hands back to its caller; the caller owns that one.
  *
  * Synchronous only: with an async `fn` the `finally` would fire at the first
- * `await`, freeing objects still in use. Every current caller is sync.
+ * `await`, freeing objects still in use. Every current caller is sync. This is
+ * enforced at runtime below — an async/thenable `fn` throws instead of
+ * silently freeing a live object.
  */
 export function withOwned<T>(
   fn: (own: <O extends Freeable>(object: O) => O) => T,
@@ -35,17 +37,34 @@ export function withOwned<T>(
   const owned: Freeable[] = [];
 
   try {
-    return fn((object) => {
+    const result = fn((object) => {
       owned.push(object);
       return object;
     });
+
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      typeof (result as { then?: unknown }).then === "function"
+    ) {
+      throw new Error(
+        "withOwned() callback returned a thenable — withOwned is synchronous-only. " +
+          "An async fn would free owned objects when the promise is *returned*, not " +
+          "when it resolves: a silent use-after-free on a still-live object.",
+      );
+    }
+
+    return result;
   } finally {
     for (const object of owned) {
       // this runs in a `finally`: a throw here would mask the real error
       try {
         object.free();
-      } catch {
-        // already freed, or never fully constructed
+      } catch (error) {
+        // Don't discard this: a genuine double-free raises a wasm trap here,
+        // and silently swallowing it hides real bugs. One failed free must
+        // not block freeing the rest, so log and keep going.
+        console.error("withOwned: object.free() threw", error);
       }
     }
   }

--- a/lib/wallet/wasm-lifecycle.ts
+++ b/lib/wallet/wasm-lifecycle.ts
@@ -26,46 +26,64 @@ type Freeable = { free: () => void };
  * that an exception later in the scope still frees it. Do NOT register an object
  * the scope hands back to its caller; the caller owns that one.
  *
- * Synchronous only: with an async `fn` the `finally` would fire at the first
- * `await`, freeing objects still in use. Every current caller is sync. This is
- * enforced at runtime below — an async/thenable `fn` throws instead of
- * silently freeing a live object.
+ * Synchronous only: with an async `fn`, `fn` itself returns at the first
+ * `await` — before any code past it has run. Every current caller is sync.
+ * This is enforced at runtime below — an async/thenable `fn` throws instead
+ * of silently freeing a live object.
+ *
+ * That guard only protects against freeing too early if it also skips
+ * cleanup on the thenable path: a `finally` runs on every exit, including a
+ * throw, so freeing there would still free objects the suspended callback's
+ * continuation hasn't used yet — the exact use-after-free this exists to
+ * catch, just paired with a thrown error instead of silent. Leaking on this
+ * misuse path is the deliberate tradeoff: it can only leak on a code path
+ * that's supposed to never execute (an async `fn`), never on the normal
+ * synchronous one.
  */
+function freeAll(owned: Freeable[]): void {
+  // LIFO: last-registered (most likely derived from an earlier one) freed
+  // first, matching Rust's own reverse-declaration drop order for the
+  // objects this module wraps.
+  for (let i = owned.length - 1; i >= 0; i--) {
+    try {
+      owned[i].free();
+    } catch (error) {
+      // A genuine double-free raises a wasm trap here. Don't let one failed
+      // free block freeing the rest, but don't discard it either.
+      console.error("withOwned: object.free() threw", error);
+    }
+  }
+}
+
 export function withOwned<T>(
   fn: (own: <O extends Freeable>(object: O) => O) => T,
 ): T {
   const owned: Freeable[] = [];
+  let result: T;
 
   try {
-    const result = fn((object) => {
+    result = fn((object) => {
       owned.push(object);
       return object;
     });
-
-    if (
-      result !== null &&
-      (typeof result === "object" || typeof result === "function") &&
-      typeof (result as { then?: unknown }).then === "function"
-    ) {
-      throw new Error(
-        "withOwned() callback returned a thenable — withOwned is synchronous-only. " +
-          "An async fn would free owned objects when the promise is *returned*, not " +
-          "when it resolves: a silent use-after-free on a still-live object.",
-      );
-    }
-
-    return result;
-  } finally {
-    for (const object of owned) {
-      // this runs in a `finally`: a throw here would mask the real error
-      try {
-        object.free();
-      } catch (error) {
-        // Don't discard this: a genuine double-free raises a wasm trap here,
-        // and silently swallowing it hides real bugs. One failed free must
-        // not block freeing the rest, so log and keep going.
-        console.error("withOwned: object.free() threw", error);
-      }
-    }
+  } catch (error) {
+    freeAll(owned);
+    throw error;
   }
+
+  if (
+    result !== null &&
+    (typeof result === "object" || typeof result === "function") &&
+    typeof (result as { then?: unknown }).then === "function"
+  ) {
+    // Do NOT free here — see the doc comment above.
+    throw new Error(
+      "withOwned() callback returned a thenable — withOwned is synchronous-only. " +
+        "An async fn would free owned objects when the promise is *returned*, not " +
+        "when it resolves: a silent use-after-free on a still-live object.",
+    );
+  }
+
+  freeAll(owned);
+  return result;
 }

--- a/lib/wallet/wasm-lifecycle.ts
+++ b/lib/wallet/wasm-lifecycle.ts
@@ -1,0 +1,52 @@
+/**
+ * Explicit lifetimes for secret-bearing wasm-bindgen objects (`PrivateKey`,
+ * `Keypair`, `XPrv`, `Mnemonic`).
+ *
+ * These types DO register with a `FinalizationRegistry` (see
+ * `wasm/core/kaspa.js`, e.g. `PrivateKeyFinalization` at :6948), so they are not
+ * stranded forever. But the JS GC only ever sees the small wrapper object and
+ * has no visibility into the much larger WASM-side allocation behind it, so it
+ * feels no pressure to collect and can run arbitrarily late. Freeing at last use
+ * makes reclamation deterministic and bounds WASM linear-memory growth.
+ *
+ * IMPORTANT — what this does NOT do: `free()` deallocates, it does not zero the
+ * bytes. The secret stays readable in linear memory until the allocator happens
+ * to reuse the region. Actually wiping key material requires `zeroize` /
+ * `ZeroizeOnDrop` on the Rust side, upstream in `@kcoin/kaspa-web3.js`. Do not
+ * describe callers of this module as wiping keys from memory.
+ */
+
+type Freeable = { free: () => void };
+
+/**
+ * Runs `fn` with an `own()` registrar and frees everything registered once `fn`
+ * returns or throws.
+ *
+ * Register an object at the moment it is created — `own(new XPrv(seed))` — so
+ * that an exception later in the scope still frees it. Do NOT register an object
+ * the scope hands back to its caller; the caller owns that one.
+ *
+ * Synchronous only: with an async `fn` the `finally` would fire at the first
+ * `await`, freeing objects still in use. Every current caller is sync.
+ */
+export function withOwned<T>(
+  fn: (own: <O extends Freeable>(object: O) => O) => T,
+): T {
+  const owned: Freeable[] = [];
+
+  try {
+    return fn((object) => {
+      owned.push(object);
+      return object;
+    });
+  } finally {
+    for (const object of owned) {
+      // this runs in a `finally`: a throw here would mask the real error
+      try {
+        object.free();
+      } catch {
+        // already freed, or never fully constructed
+      }
+    }
+  }
+}

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -30,6 +30,11 @@ import {
 } from "@/lib/wallet/sign-script";
 import { SIGN_TYPE, toSignType } from "@/lib/kaspa";
 import { SignTxPayloadSchema } from "@/api/background/handlers/kaspa/utils";
+import {
+  AccountFactory,
+  LegacyAccountFactory,
+} from "@/lib/wallet/account-factory";
+import { withOwned } from "@/lib/wallet/wasm-lifecycle";
 import type { SignType } from "@/lib/wallet/wallet-interface";
 
 // Throwaway key — unit tests only, never funded.
@@ -1160,5 +1165,203 @@ test.describe("ledger derivation unification (B2/C/D)", () => {
     expect(tx.inputs[0].utxo).toBeUndefined();
 
     await expect(account.signTx(tx)).rejects.toThrow(/missing its UTXO entry/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W1 — explicit lifetimes for secret-bearing WASM objects (wasm-lifecycle.ts).
+// These objects are now freed at last use, which means a misplaced free shows
+// up as "null pointer passed to rust" on the signing path. The derivation
+// vectors below were captured from `main` BEFORE any free() was introduced and
+// are hardcoded on purpose: comparing the two branches to each other would pass
+// even if both were wrong, and at accountIndex 0 the two derivation paths
+// coincide, so only indexes 1 and 3 can catch a branch swap.
+// ---------------------------------------------------------------------------
+
+const W1_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+const W1_VECTORS = [
+  {
+    branch: "legacy",
+    accountIndex: 0,
+    address:
+      "kaspa:qqd6e65yefepe9wk0m9vuxdufxd80sphy67gwwd0vdaumzdt4tc9s3qt0lqeh",
+    firstPublicKey:
+      "031bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058",
+  },
+  {
+    branch: "legacy",
+    accountIndex: 1,
+    address:
+      "kaspa:qzyqe0y64jqvx043jd0mpgugrd00y39zp0t7j64854k7r0ln2eu3vck8n7p07",
+    firstPublicKey:
+      "03880cbc9aac80c33eb1935fb0a3881b5ef244a20bd7e96aa7a56de1bff3567916",
+  },
+  {
+    branch: "legacy",
+    accountIndex: 3,
+    address:
+      "kaspa:qrgg2k6l7r96x8ckw64rncttgsxs0zgdm2jsz20x4p4392ypjejsgx38gqhvj",
+    firstPublicKey:
+      "02d0855b5ff0cba31f1676aa39e16b440d07890ddaa50129e6a86b12a881966504",
+  },
+  {
+    branch: "new",
+    accountIndex: 0,
+    address:
+      "kaspa:qqd6e65yefepe9wk0m9vuxdufxd80sphy67gwwd0vdaumzdt4tc9s3qt0lqeh",
+    firstPublicKey:
+      "031bacea84ca721c95d67ecace19bc499a77c03726bc8739af637bcd89abaaf058",
+  },
+  {
+    branch: "new",
+    accountIndex: 1,
+    address:
+      "kaspa:qp6r0d88yj4fazlj057wc35245jfgs87n9jn6nahfg223996dfukvgpgq6pcp",
+    firstPublicKey:
+      "027437b4e724aa9e8bf27d3cec468aad249440fe99653d4fb74a14a894ba6a7966",
+  },
+  {
+    branch: "new",
+    accountIndex: 3,
+    address:
+      "kaspa:qqwn552u0tdqgcggarzeh2x5nh8lmkgzfg4nqay8vtl9pf975aw3ww9w4xy35",
+    firstPublicKey:
+      "021d3a515c7ada046108e8c59ba8d49dcffdd9024a2b30748762fe50a4bea75d17",
+  },
+] as const;
+
+function w1Factory(branch: string) {
+  return branch === "legacy"
+    ? new LegacyAccountFactory()
+    : new AccountFactory();
+}
+
+// a P2PK script paying the wallet's own derived key, so signTransaction can
+// actually satisfy the input it is handed
+function w1TxFor(xOnlyPublicKey: string) {
+  const spk = "0000" + "20" + xOnlyPublicKey + "ac";
+
+  return Transaction.deserializeFromSafeJSON(
+    JSON.stringify({
+      id: "00".repeat(32),
+      version: 0,
+      inputs: [
+        {
+          transactionId: "11".repeat(32),
+          index: 0,
+          sequence: "0",
+          sigOpCount: 1,
+          computeBudget: 0,
+          signatureScript: "",
+          utxo: {
+            address: null,
+            amount: "100000000",
+            scriptPublicKey: spk,
+            blockDaaScore: "1000",
+            isCoinbase: false,
+          },
+        },
+      ],
+      outputs: [{ value: "90000000", scriptPublicKey: spk }],
+      lockTime: "0",
+      subnetworkId: "00".repeat(20),
+      gas: "0",
+      payload: "",
+    }),
+  );
+}
+
+test.describe("WASM secret lifecycle (W1)", () => {
+  for (const v of W1_VECTORS) {
+    test(`${v.branch} branch derives unchanged addresses at index ${v.accountIndex}`, async () => {
+      const wallet = w1Factory(v.branch).createFromMnemonic(
+        W1_MNEMONIC,
+        v.accountIndex,
+      );
+
+      expect((await wallet.getPublicKeys())[0]).toBe(v.firstPublicKey);
+      expect(
+        (await wallet.getPublicKey()).toAddress("mainnet").toString(),
+      ).toBe(v.address);
+    });
+
+    test(`${v.branch} branch survives repeated use at index ${v.accountIndex}`, async () => {
+      // a use-after-free surfaces as "null pointer passed to rust" on the
+      // second iteration, so repetition is the cheap detector here
+      const wallet = w1Factory(v.branch).createFromMnemonic(
+        W1_MNEMONIC,
+        v.accountIndex,
+      );
+
+      for (let i = 0; i < 20; i++) {
+        expect((await wallet.getPublicKeys())[0]).toBe(v.firstPublicKey);
+        expect(
+          (await wallet.getPublicKey()).toAddress("mainnet").toString(),
+        ).toBe(v.address);
+        expect(await wallet.signMessage("kastle-w1")).toMatch(
+          /^[0-9a-f]{128}$/,
+        );
+      }
+    });
+  }
+
+  test("the two derivation branches stay distinct away from index 0", () => {
+    // guards the isLegacy landmine itself: if the paths were ever swapped or
+    // unified, these would collide
+    const legacy = W1_VECTORS.filter((v) => v.branch === "legacy");
+    const modern = W1_VECTORS.filter((v) => v.branch === "new");
+
+    for (const index of [1, 3]) {
+      const l = legacy.find((v) => v.accountIndex === index)!;
+      const m = modern.find((v) => v.accountIndex === index)!;
+      expect(l.address).not.toBe(m.address);
+    }
+  });
+
+  for (const v of W1_VECTORS) {
+    test(`${v.branch} branch still signs a transaction at index ${v.accountIndex}`, async () => {
+      const wallet = w1Factory(v.branch).createFromMnemonic(
+        W1_MNEMONIC,
+        v.accountIndex,
+      );
+      const xOnly = (await wallet.getPublicKey()).toXOnlyPublicKey().toString();
+
+      // repeated on purpose: the per-input PrivateKey in sign-script.ts is now
+      // freed, so a use-after-free shows up on the second pass as
+      // "null pointer passed to rust" rather than a wrong signature
+      for (let i = 0; i < 5; i++) {
+        const signed = await wallet.signTx(w1TxFor(xOnly), []);
+        expect(signed.inputs[0].signatureScript).toBeTruthy();
+      }
+    });
+  }
+
+  test("free() really deallocates, so reuse throws rather than silently succeeding", () => {
+    // documents the semantics every other test in this block relies on
+    const key = new PrivateKey(TEST_KEY);
+    expect(key.toString()).toBe(TEST_KEY);
+
+    key.free();
+
+    expect(() => key.toString()).toThrow();
+  });
+
+  test("withOwned frees what it owns even when the body throws", () => {
+    let freed = false;
+    const probe = {
+      free() {
+        freed = true;
+      },
+    };
+
+    expect(() =>
+      withOwned((own) => {
+        own(probe);
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(freed).toBe(true);
   });
 });

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -1364,4 +1364,21 @@ test.describe("WASM secret lifecycle (W1)", () => {
     ).toThrow("boom");
     expect(freed).toBe(true);
   });
+
+  test("withOwned throws when the callback returns a thenable", () => {
+    let freed = false;
+    const probe = {
+      free() {
+        freed = true;
+      },
+    };
+
+    expect(() =>
+      withOwned((own) => {
+        own(probe);
+        return (async () => undefined)();
+      }),
+    ).toThrow(/synchronous-only/);
+    expect(freed).toBe(true);
+  });
 });

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -1379,6 +1379,45 @@ test.describe("WASM secret lifecycle (W1)", () => {
         return (async () => undefined)();
       }),
     ).toThrow(/synchronous-only/);
-    expect(freed).toBe(true);
+    // Must NOT be freed: the thrown error aborts withOwned(), but the async
+    // callback is still suspended and may resume later. Freeing here would
+    // be the exact use-after-free this guard exists to catch.
+    expect(freed).toBe(false);
+  });
+
+  test("withOwned does not free an owned object out from under a still-running async callback", async () => {
+    let freed = false;
+    const probe = {
+      free() {
+        freed = true;
+      },
+    };
+    let usedWhileStillUnfreed = false;
+    let pending: Promise<void> | undefined;
+    let sawError: unknown;
+
+    try {
+      withOwned((own) => {
+        own(probe);
+        pending = (async () => {
+          await Promise.resolve();
+          // If withOwned had freed `probe` synchronously (the old bug), this
+          // would be a use-after-free in real wasm code.
+          usedWhileStillUnfreed = !freed;
+        })();
+        return pending;
+      });
+    } catch (error) {
+      sawError = error;
+    }
+
+    expect(sawError).toBeInstanceOf(Error);
+    expect(freed).toBe(false);
+
+    await pending;
+    expect(usedWhileStillUnfreed).toBe(true);
+    // withOwned() never frees on this path — the object leaks rather than
+    // being corrupted out from under the still-suspended callback.
+    expect(freed).toBe(false);
   });
 });


### PR DESCRIPTION
Frees secret-bearing wasm-bindgen objects (`PrivateKey`, `Keypair`, `XPrv`, `Mnemonic`) at last use instead of leaving them to the GC. Call-site changes only — no dependency, `wasm/`, `assets/` or `package*.json` drift.

Full write-up in `W1_SUMMARY.md`; evidence trail in `W1_INVESTIGATION.md`.

## Please read this before the diff

**Two things this PR must not be mistaken for.**

**1. This is not a leak fix.** The premise it started from — that these objects are never freed — is false. Every secret-bearing class registers with a `FinalizationRegistry` on *both* allocation paths (`__wrap` and the constructor), e.g. `PrivateKeyFinalization` at `wasm/core/kaspa.js:6948`. Nothing is stranded forever.

The actual defect is a **GC-visibility gap**: the JS heap object is a ~50-byte wrapper holding a pointer, while the allocation it owns lives in WASM linear memory the GC cannot see and feels no pressure from. So the wrapper survives arbitrarily long, and the secret with it. Freeing at last use makes reclamation deterministic and bounds linear-memory growth.

**2. This does not wipe keys from memory.** `free()` returns the allocation to the WASM allocator; it does **not** zero the bytes. The secret stays readable in linear memory until the allocator happens to reuse that region — possibly never. This fixes reclamation outright and helps exposure only *probabilistically*. Please don't describe it as "keys are now wiped."

The real fix for exposure is `zeroize` / `ZeroizeOnDrop` on the Rust side, upstream in `@kcoin/kaspa-web3.js`. `W1_SUMMARY.md` §8 has a drafted question for the maintainers.

**The larger exposure is untouched.** `toSeed()`, `Keypair.privateKey`, `XPrv.privateKey` and `PrivateKey.toString()` all return **plain JS strings**, and `LegacyHotWalletAccount` holds the master seed as `protected readonly seed: string` for its entire lifetime. Immutable strings cannot be zeroed in any runtime. That surface is strictly larger than what this PR fixes, and is arguably the more important finding of the investigation.

**Severity graded Low-to-Medium**, not higher: the `FinalizationRegistry` exists, MV3 service-worker teardown hard-bounds the background instance, and exploiting this requires code execution in the extension's own context — where an attacker can read the decrypted mnemonic from wallet state directly and has no need to scrape linear memory.

## Why freeing here is provably safe

Checked the generated glue for every callee before writing a single `.free()`, looking for `_assertClass` (type-check = borrow) vs `__destroy_into_raw` (consumes):

| Callee | `_assertClass` | `__destroy_into_raw` | Semantics |
|---|---|---|---|
| `createInputSignature` L1122 | yes | no | borrows |
| `signTransaction` L1063 | yes | no | borrows |
| `signScriptHash` L1087 | yes | no | borrows |
| `signMessage` L1231 | — | — | takes a `string` |

No method consumes `this`, and derived objects are independent allocations (`derivePath` → `XPrv.__wrap`, `toPrivateKey` → `PrivateKey.__wrap`, …), so freeing a parent after deriving from it is safe. Verified by reading the glue, not inferred.

## What changed

One new file, `lib/wallet/wasm-lifecycle.ts` (52 lines), exporting a single scope guard:

```ts
export function withOwned<T>(fn: (own: <O extends Freeable>(o: O) => O) => T): T
```

Register at creation — `own(new XPrv(seed))` — and everything registered is freed when the scope returns *or throws*. Chosen over hand-written nested `try/finally` because the deepest site nests three objects. **Synchronous only** — with an async `fn` the `finally` would fire at the first `await` and free objects still in use; every current caller is sync and the doc comment says so.

No `FinalizationRegistry` was added — one already exists upstream.

**Fixed (bucket A, 13 sites):** the per-input `PrivateKey` on the signing path, all hot-wallet derivation on both classes, both account factories, the Ethereum factory, and three import screens whose validation effects were allocating a fresh `Mnemonic`/`PrivateKey` **per keystroke**.

**Deliberately not touched:**
- **Bucket B** — objects returned to callers (`getPrivateKey`, `getPublicKey` return values). Freeing at the alloc site would be use-after-free.
- **Bucket C** — `HotWalletPrivateKey`'s instance-held `PrivateKey` (`hot-wallet-private-key.ts:16`) and `createFromPrivateKey`. There is no disposal hook and no caller that knows when the account is done; inventing a lifecycle contract means touching wallet teardown, outside "call-site changes only" and inside the signing blast radius. Listed rather than guessed. Main follow-up.

## The `isLegacy` landmine

```
legacy: m/44'/111111'/{accountIndex}'/0/{index}
new:    m/44'/111111'/0'/0/{accountIndex}
```

**At `accountIndex` 0 these coincide.** A test covering only index 0 passes straight through a branch swap. Vectors are therefore pinned at indexes **0, 1 and 3**, generated programmatically from unmodified code rather than transcribed:

| Branch / index | Address (truncated) |
|---|---|
| legacy 0 | `kaspa:qqd6e65yefepe9wk0m9vux…` |
| new 0 | *identical* — the trap |
| legacy 1 | `kaspa:qzyqe0y64jqvx043jd0mpg…` |
| new 1 | `kaspa:qp6r0d88yj4fazlj057wc3…` |
| legacy 3 | `kaspa:qrgg2k6l7r96x8ckw64rnc…` |
| new 3 | `kaspa:qqwn552u0tdqgcggarzeh2…` |

Also worth knowing: Kaspa schnorr message signing uses aux randomness, so signatures are non-deterministic and cannot be pinned. Tests assert on derived addresses/pubkeys and check signatures structurally.

## Verification

| Check | Result |
|---|---|
| `npm run compile` | ✅ 0 errors |
| eslint / prettier | ✅ both exit 0 |
| `tests/signtx-unit.spec.ts` | ✅ **61 passed** (40 baseline + 21 new) |
| `package.json` / `package-lock.json` drift | ✅ **0 lines** |
| `wasm/` + `assets/` drift | ✅ **0 lines** |
| Both `isLegacy` branches unchanged | ✅ vectors at 0/1/3 |
| Guards #306 / #308 / #310 / #312 | ✅ byte-identical to `main` |
| `npm run e2e` | ✅ 61 passed, 1 failure — pre-existing |

The only edit inside `sign-script.ts` is the L205 allocation: one import line plus the wrapped call. Every guard function is unchanged.

**Two notes for whoever re-runs this.**

`npm run prettier` returns a bogus exit code and the local `rtk` shim prints a fabricated "All files formatted correctly" banner regardless of the true result. Run `./node_modules/.bin/prettier --check .` directly and trust the exit code — doing so surfaced a real failure the banner had hidden.

`onboarding.spec.ts:7` fails with *"Test timeout of 30000ms exceeded while setting up context"*. Re-ran once, then checked out `main` (`a441e75`) and ran it there — **fails identically**. Pre-existing environment failure, not a regression. Flagging that it is believed to pass on recent runs, so either the environment differs or that belief is stale; worth reconciling separately.

## Manual QA — required before merge

Not yet performed. A QA build exists locally, marked `Kastle [W1 QA] / 2.59.5-w1-wasm-secret-lifecycle`.

Confirm the manifest shows that marking before trusting any result — a stale build silently answered an entire QA run once before, and version strings collide. Static check: `"cannot complete sign-only requests"` must be present in the bundle. Note that `"advanced scripts signing"` is **not** a staleness signal — `LedgerSignTx.tsx:28-29` is one ternary and both strings ship in every post-#308 build. Only the sign-only string discriminates.

One extension per Chrome profile: two Kastle builds in one profile race to inject `window.kastle`.

| # | Check | ⚠️ |
|---|---|---|
| 1 | Send on a new-derivation wallet | |
| 2 | Send on a legacy wallet | ⚠️ |
| 3 | Sign a message — new-derivation | |
| 4 | Sign a message — legacy | ⚠️ |
| 5 | Lock / unlock — addresses identical after | |
| 6 | dApp `signAndBroadcastTx` | |
| 7 | Import recovery phrase, typing 20+ chars | |
| 8 | Import private key | |
| 9 | Account list — all 50 legacy addresses render | |
| 10 | Ethereum account, both branches | ⚠️ |

⚠️ = touches the `isLegacy` landmine. Rows 1–6 must be run on **both** wallet types; a fix that works on one branch and breaks the other is a wrong-key-signs bug. For rows 1–4 the highest-value check is simply: **is the derived address the same one that wallet showed before this build?** If any address moved, stop.

## Follow-ups (not in this PR)

1. Upstream `ZeroizeOnDrop` in `@kcoin/kaspa-web3.js` — the only real fix for exposure. Note the package and WASM binary are certified crypto inventory (audited 2026-07-29), so any bump is a re-certification event.
2. Bucket C lifecycle for `HotWalletPrivateKey`.
3. The plaintext JS-string seed surface — largest remaining exposure, depends on (1).
4. Reconcile `onboarding.spec.ts:7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for temporary cryptographic objects during wallet creation, key validation, derivation, and signing.
  * Added a lifecycle utility that releases managed resources when operations complete or fail.

* **Bug Fixes**
  * Reduced delayed memory reclamation for secret-bearing objects without changing wallet derivation or signing behavior.
  * Added clearer error reporting when managed-resource cleanup fails.

* **Tests**
  * Added coverage for repeated key access, signing, derivation branches, explicit cleanup, and cleanup after errors.

* **Documentation**
  * Documented lifecycle findings, supported cleanup behavior, limitations, and follow-up considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->