### PR TITLE
fix: scrub secret material from Sentry events and breadcrumbs

### DIFF
--- a/S1_SUMMARY.md
+++ b/S1_SUMMARY.md
@@ -12,7 +12,7 @@ Two commits:
 | SHA       | Subject                                                                            |
 | --------- | ---------------------------------------------------------------------------------- |
 | `6d8aaeb` | `fix: scrub secret material from Sentry events and breadcrumbs`                    |
-| `2bcd44a` | `fix: drop dead getPrivateKeys and stop materialising keys as hex for signMessage` |
+| `56f8264` | `fix: drop dead getPrivateKeys and stop materialising keys as hex for signMessage` |
 
 ```
  lib/instrument.ts                            |   9 ++
@@ -384,9 +384,9 @@ read back off disk to verify:
 
 ```json
 {
-  "name": "Kastle (QA S1 2bcd44a)",
+  "name": "Kastle (QA S1 56f8264)",
   "version": "2.59.6",
-  "version_name": "2.59.6-s1-qa-2bcd44a"
+  "version_name": "2.59.6-s1-qa-56f8264"
 }
 ```
 
@@ -403,7 +403,7 @@ The unit tests prove the redactor. This proves the **wiring** — that the redac
 actually on the path to the network.
 
 1. **Load the QA build.** `chrome://extensions` → Developer mode → Load unpacked →
-   `~/Desktop/kastle-qa-s1/`. Confirm the tile reads `Kastle (QA S1 2bcd44a)`.
+   `~/Desktop/kastle-qa-s1/`. Confirm the tile reads `Kastle (QA S1 56f8264)`.
 
 2. **Import a known throwaway phrase.** Use a phrase you can grep for and would never
    fund, e.g.

--- a/S1_SUMMARY.md
+++ b/S1_SUMMARY.md
@@ -537,6 +537,37 @@ production bundle. The `import.meta.env.DEV` gate strips the block.
 - `playwright test tests/signtx-unit.spec.ts` → **80 passed** (76 existing + 4 new)
 - `git diff main...HEAD -- package.json package-lock.json wasm/ assets/ ledger-account.ts` → 0 bytes
 
+## Review follow-ups (CodeRabbit / Copilot on PR #326)
+
+Three findings, all verified against the code before acting — two were real
+holes in the scrubber, one was a documentation request.
+
+**1. `\b` anchors let concatenated secrets through.** Confirmed empirically:
+`` `key${hex}` `` was **not** redacted, because `\b` needs a non-word character
+on each side and `y` is a word character. String concatenation is exactly how a
+key reaches a log line, so this was a real gap. `HEX_KEY_PATTERN` now uses
+lookarounds that reject only adjacent _hex_ characters
+(`/(?<![0-9a-fA-F])(?:0x)?[0-9a-fA-F]{64}(?![0-9a-fA-F])/g`), which keeps a
+longer hex blob intact while catching the concatenated case.
+
+`EXTENDED_KEY_PATTERN` had the same hole, unflagged. A lookbehind cannot fix it
+— the key body is alphanumeric, so "not preceded by an alphanumeric" would
+reject `` `seed${xprv}` `` too — so it is simply unanchored:
+`/[xk]prv[0-9A-Za-z]{20,}/g`. Over-matching is the safe direction.
+
+**2. `kprv` missing from `SECRET_KEY_PATTERN`.** The _value_ pattern already
+covered `kprv`, the _key-name_ pattern did not, so a field literally named
+`kprv` holding a non-string was missed. Now `[xk]prv`.
+
+**3. `HotWalletPrivateKey` constructor ownership undocumented.** Checked all
+three call sites (`account-factory.ts` ×2, the unit test): every one constructs
+`new PrivateKey(...)` inline and hands it over, so no caller can free it out
+from under the instance. No behaviour change needed; added a constructor comment
+stating that ownership transfers.
+
+Three regression tests added: concatenated hex and xprv, a 128-char hex blob
+left intact, and a `kprv`-named key. 83 tests pass.
+
 ## Human gates — nothing done past the working tree
 
 No push, no PR, no tag, no merge, no release. Two local commits on

--- a/S1_SUMMARY.md
+++ b/S1_SUMMARY.md
@@ -1,0 +1,483 @@
+# S1 — Sentry secret scrubbing + W1b Tier-1 cleanup
+
+Branch `fix/sentry-secret-scrubbing`, based on `main` @ `8d3d801`.
+
+**Base note:** the task specified `main` @ `6637ad9`. `main` has since advanced to
+`8d3d801` (`chore(main): release 2.59.6`), which is a release-please version bump only
+— no source change. Basing on `8d3d801` keeps the branch on current `main` and keeps
+G4 honest (a branch cut at `6637ad9` would show a spurious `package.json` diff).
+
+Two commits:
+
+| SHA       | Subject                                                                            |
+| --------- | ---------------------------------------------------------------------------------- |
+| `6d8aaeb` | `fix: scrub secret material from Sentry events and breadcrumbs`                    |
+| `2bcd44a` | `fix: drop dead getPrivateKeys and stop materialising keys as hex for signMessage` |
+
+```
+ lib/instrument.ts                            |   9 ++
+ lib/sentry-scrub.ts                          | 112 +++++++++++++++++
+ lib/wallet/account/hot-wallet-account.ts     |  30 +----
+ lib/wallet/account/hot-wallet-private-key.ts |   5 +-
+ tests/signtx-unit.spec.ts                    | 175 +++++++++++++++++++++++++++
+ 5 files changed, 306 insertions(+), 25 deletions(-)
+```
+
+---
+
+## P0 — What Sentry actually captured
+
+### a. Package and version
+
+`package.json` declares `"@sentry/react": "^9.0.0"`. Installed and locked:
+`@sentry/react`, `@sentry/browser` and `@sentry/core` all **9.12.0**.
+
+`sendDefaultPii`'s effective default in 9.12.0: **unset**. `applyDefaultOptions()` in
+`node_modules/@sentry/browser/build/npm/cjs/sdk.js` sets only `defaultIntegrations`,
+`release` and `sendClientReports` — `sendDefaultPii` is never defaulted, so it arrived
+as `undefined` and every consumer read it as falsy. Falsy-by-accident, not false-by-
+contract, which is why it is now set explicitly.
+
+In the browser SDK the option has a narrow blast radius anyway: its only readers are
+`requestDataIntegration` (IP address) and `trpcMiddleware`, neither of which is in the
+browser default set. It was **not** the vector.
+
+### b. Session Replay — OFF (confirmed, not assumed)
+
+This is the question that would have escalated the finding to confirmed-critical, and
+the answer is no, on three independent checks:
+
+1. `replayIntegration` is **absent from `getDefaultIntegrations()`** in
+   `@sentry/browser` 9.12.0 (full list in P0c below).
+2. There is exactly one `Sentry.init` in the repo and it passes no `integrations`
+   array, so nothing adds it.
+3. `grep -rl "replayIntegration" .output/` over the **built extension** returns
+   nothing. Not merely unconfigured — absent from the shipped bytes.
+
+No DOM capture of the displayed phrase was ever in play. Nothing to disable; S1.3 is a
+no-op, deliberately.
+
+### c. Default integrations in 9.12.0
+
+From `getDefaultIntegrations()`:
+
+`inboundFilters`, `functionToString`, **`browserApiErrors`**, **`breadcrumbs`**,
+**`globalHandlers`**, `linkedErrors`, `dedupe`, `httpContext`, `browserSession`.
+
+`breadcrumbsIntegration`'s defaults are all-on, including **`console: true`** and
+`dom: true`. The console handler joins the logged arguments with `safeJoin()` straight
+into `breadcrumb.message`, and attaches `handlerData.args` as the hint.
+
+**So the plausible vector was real and was exactly as suspected:** console breadcrumbs
+plus `globalHandlers`. Any `console.*` argument, and any unhandled error or rejection
+message, was serialised verbatim into the outbound envelope with nothing between it and
+the wire.
+
+### d. Screens holding secret material
+
+`ShowWalletSecret.tsx` gates on a `WalletSecret` in `useState` and hands `secret.value`
+as a prop to `ShowRecoveryPhrase` / `ShowPrivateKey`, which render the phrase word by
+word into `<input>` elements. Files that reference `mnemonic` / `privateKey` /
+`phrase` / `passphrase` in the UI and hook layers:
+
+```
+components/onboarding/ChooseImport.tsx
+components/screens/AddWallet.tsx
+components/screens/Dashboard.tsx
+components/screens/Onboarding.tsx
+components/screens/full-pages/ImportPrivateKey.tsx
+components/screens/full-pages/ImportRecoveryPhrase.tsx
+components/screens/full-pages/ImportRecoveryPhraseWithPassphrase.tsx
+components/screens/full-pages/account-management/ManageAccounts.tsx
+components/screens/full-pages/show-wallet-secret/ShowPrivateKey.tsx
+components/screens/full-pages/show-wallet-secret/ShowRecoveryPhrase.tsx
+components/screens/full-pages/show-wallet-secret/ShowWalletSecret.tsx
+components/side-menu/RecoveryPhraseWalletItem.tsx
+components/side-menu/SideMenu.tsx
+entrypoints/popup/router.tsx
+hooks/wallet/useAccountManager.ts
+hooks/wallet/useWalletImporter.ts
+ui/full-page/import-passphrase/ImportPassphrasePage.tsx
+ui/full-page/import-recovery-phrase/ImportRecoveryPhrasePage.tsx
+ui/full-page/import-wallet/ImportWalletPage.tsx
+ui/general/PassphraseInfoModal.tsx
+ui/popup/add-wallet/AddWalletPage.tsx
+```
+
+All of them live in the popup, which is the one entry point that loads Sentry.
+
+### e. `console.*` reachable from those screens
+
+32 call sites across `components/ hooks/ ui/ lib/ entrypoints/ contexts/`. **None logs
+a secret directly** — they are almost entirely `console.error(error)` in `catch`
+blocks, plus one `console.log` banner in `entrypoints/popup/main.tsx`.
+
+That is the honest read, and it is why the original status was INFERRED. The exposure
+was never "we log the phrase today"; it was that the import and backup flows pass raw
+phrases through code whose `catch` blocks log the caught error unconditionally, with no
+scrubbing between that and Sentry. One WASM error string or one added debug line was
+the whole distance to a leak.
+
+### f. `Sentry.init` call sites — exactly one
+
+`lib/instrument.ts`, imported only by `entrypoints/popup/main.tsx`. The background
+service worker and the content scripts do not initialise Sentry. One site to fix.
+
+**P0 verdict:** Session Replay off, `sendDefaultPii` inert, but console breadcrumbs and
+`globalHandlers` on and unscrubbed. Passive continuous exposure with a short fuse, and
+the fix is cheap — so it ships regardless.
+
+---
+
+## S1 — The fix
+
+### `lib/sentry-scrub.ts` (new, 112 lines)
+
+Pure and Sentry-independent so it unit tests directly. `scrubPayload()` walks an
+arbitrary payload recursively and redacts by two independent rules:
+
+**By pattern**, applied to every string:
+
+| Rule            | Pattern                                                                                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BIP-39 phrase   | ≥ 12 consecutive dictionary words. Separators between the words are not inspected, so a phrase pasted with commas, newlines or numbering is still caught. |
+| Private key hex | `\b(?:0x)?[0-9a-fA-F]{64}\b` — covers secp256k1 and Kaspa private keys, bare or `0x`-prefixed.                                                            |
+| Extended key    | `\b[xk]prv[0-9A-Za-z]{20,}\b` — BIP-32 `xprv…` and the Kaspa `kprv…` variant.                                                                             |
+
+**By field name**, matched case-insensitively against
+`seed|mnemonic|privatekey|phrase|passphrase|password|secret|xprv`. A matching key has
+its value replaced whatever the value is — string, number, `null`, or a whole nested
+object. This catches `privateKeyString` and `seedSource` via substring, by design.
+
+**Recursion.** The walk covers the entire payload — `message`, `exception.values`,
+`breadcrumbs[].data`, `extra`, `contexts`, `request`, arrays, and anything nested at any
+depth. A `WeakSet` breaks cycles (a repeat resolves to `[REDACTED]`). Objects with no
+enumerable own keys — `Error`, `Date`, class instances — are handed back untouched
+rather than rebuilt into `{}`, which would have destroyed the payload; Sentry serialises
+those itself.
+
+**Fail-safe.** The whole walk is wrapped. If redaction throws for any reason,
+`scrubPayload` returns `null`, and Sentry treats `null` from `beforeSend` /
+`beforeBreadcrumb` as _drop_. It fails closed, never sending an unscrubbed payload.
+
+The BIP-39 wordlist comes from `viem`, which is already a **direct** dependency and
+already imported by `lib/utils.ts`. No dependency change, no new bundle cost, and no
+hand-rolled word heuristic that would have over-redacted ordinary prose.
+
+### `lib/instrument.ts`
+
+```ts
+Sentry.init({
+  dsn: "…",
+  enabled: isProduction,
+  sendDefaultPii: false,
+  beforeSend: (event) => scrubPayload(event),
+  beforeBreadcrumb: (breadcrumb) => scrubPayload(breadcrumb),
+});
+```
+
+- **S1.1** — both hooks wired, recursive, fail-closed. ✅
+- **S1.2** — `sendDefaultPii: false` set explicitly, not inherited. ✅
+- **S1.3** — Session Replay is off and absent from the build; nothing to disable or
+  mask. Stated rather than changed. ✅
+- **S1.4** — one `Sentry.init` site exists and it is this one. ✅
+- **S1.5 — skipped, deliberately.** Disabling Sentry on secret-bearing routes is not a
+  clean few lines here: the SDK has no route predicate, so it would mean either a
+  module-level mutable flag that every secret screen sets and clears on mount/unmount
+  (leaks on an unmount that never fires, and races with async errors that surface after
+  navigation), or threading the router state into `beforeSend`. Both are more moving
+  parts than the control they would back up. The scrubber is route-independent and
+  covers every screen including ones not written yet, which is the stronger property.
+
+**Verified in the built bundle, not just the source:** `.output/chrome-mv3/chunks/popup-*.js`
+contains `[REDACTED]`, `sendDefaultPii: false`, `beforeSend: (event) => scrubPayload(event`,
+`beforeBreadcrumb: (breadcrumb) => scrubPayload(`, and the BIP-39 wordlist.
+
+---
+
+## S2 — Tests
+
+12 tests in `tests/signtx-unit.spec.ts` under `sentry secret scrubbing`, exercising the
+redactor directly:
+
+| #   | Test                                                                                                                       | Covers                          |
+| --- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| 1   | 12-word BIP-39 phrase in a message                                                                                         | required                        |
+| 2   | 24-word BIP-39 phrase in a message                                                                                         | required                        |
+| 3   | phrase pasted with commas and newlines                                                                                     | separator robustness            |
+| 4   | 64-char hex key, bare **and** `0x`-prefixed                                                                                | required                        |
+| 5   | `xprv…` extended key                                                                                                       | required                        |
+| 6   | secrets nested in `extra`, `contexts` and a breadcrumb's `data`                                                            | required (nested)               |
+| 7   | a breadcrumb payload scrubbed like an event                                                                                | `beforeBreadcrumb` path         |
+| 8   | field-name match with harmless values (`"hello"`, `42`, `""`, `null`, nested object) — **and** a non-secret key left alone | required (field-name)           |
+| 9   | benign event passes through `toEqual`-unchanged                                                                            | required (over-redaction guard) |
+| 10  | ordinary long English prose untouched                                                                                      | over-redaction guard            |
+| 11  | scrubber throws → returns `null` → event dropped                                                                           | required (fail-safe)            |
+| 12  | cyclic payload neither hangs nor leaks                                                                                     | robustness                      |
+
+Tests 9 and 10 are the ones that keep Sentry useful: 9 asserts deep equality on a
+realistic error event carrying a Kaspa **address** (superficially key-like) and a
+version string, and 10 asserts a 24-word English sentence survives intact.
+
+---
+
+## S3 — W1b Tier-1 cleanup
+
+Both items verified independently. The W1b findings were not taken on trust.
+
+### S3.1 — `getPrivateKeys()` ×2 — **deleted**
+
+Zero callers, verified two ways before deleting:
+
+- `graphify query` on the graph at `~/Repositories/kastle/graphify-out/graph.json`.
+- `grep -rn "getPrivateKeys" .` across the whole repo including `tests/`, excluding
+  only `node_modules/.git/.output/dist`. Result: **two definition lines**
+  (`hot-wallet-account.ts:74`, `:121`) and four hits in `W1_INVESTIGATION.md` /
+  `W1_SUMMARY.md`, which are prose. No call site anywhere.
+
+The W1b claim that the override ignores its `indexes` parameter is confirmed by the
+source _and_ corroborated independently by eslint: the baseline run flagged
+`hot-wallet-account.ts:121:27 'indexes' is defined but never used`, and deleting the
+methods is exactly what removes it (40 → 39 warnings, diffed below).
+
+### S3.2 — `signMessage` object passing — **applied**, ownership confirmed empirically
+
+`ISignMessage.privateKey` is typed `PrivateKey | string` (`wasm/core/kaspa.d.ts:2515`),
+so the object form is supported. The question W1 raised is whether the WASM boundary
+_borrows_ or _consumes_, and that could not be settled by reading compiled glue — so it
+was measured against the built `assets/kaspa_bg.wasm` with a throwaway spec:
+
+| Probe                                          | Result                                      |
+| ---------------------------------------------- | ------------------------------------------- |
+| `signMessage` twice with the same `PrivateKey` | both succeed                                |
+| `pk.toString()` after signing                  | succeeds — pointer still live               |
+| `pk.free()` after all of the above             | succeeds — **this** was the first real free |
+| `pk.free()` a second time                      | throws `Error: null pointer passed to rust` |
+| object path vs string path, `noAuxRand: true`  | **byte-identical signature**                |
+
+Same shape as `createInputSignature` in W1: **borrows, caller retains ownership and
+must free.** The double-free throwing is the load-bearing receipt — it proves
+`signMessage` did not null the pointer, because if it had, the first `free()` would have
+been the one to throw.
+
+(The first probe run without `noAuxRand` produced differing signatures each call. That
+is Schnorr aux randomness, not a semantic difference — `noAuxRand: true` makes it
+deterministic and the two paths then agree byte for byte.)
+
+Applied in two places:
+
+- `hot-wallet-account.ts:58` — `getPrivateKey()` documents that it hands ownership to
+  the caller, so the object is wrapped in `withOwned` and freed:
+  ```ts
+  return withOwned((own) =>
+    signMessage({ message, privateKey: own(this.getPrivateKey()) }),
+  );
+  ```
+  `withOwned` is sync-only and `signMessage` returns synchronously, so the
+  #324 thenable guard is not in play.
+- `hot-wallet-private-key.ts:37` — the instance owns `this.privateKey` for its whole
+  lifetime (constructed inline at `account-factory.ts:38,67`, no other reference, never
+  freed), so the object is passed directly with **no** `withOwned`.
+
+Both drop a hex private key string that was previously materialised in JS memory purely
+to hand back to WASM.
+
+**Coverage.** `HotWalletAccount.signMessage` was already covered — the W1 suite calls it
+20 times per variant across 6 legacy/new × index combinations, asserting a valid
+128-hex signature, which is a strong repeated-use / no-use-after-free receipt for the
+`withOwned` change. `HotWalletPrivateKey` had **no** coverage, so one test was added:
+20 repeated calls plus a byte-identical comparison against the string path under
+`noAuxRand`.
+
+### S4 — out of scope, untouched
+
+`sign-script.ts` object passing, any seed/`Uint8Array` refactor, Sentry token rotation,
+and `ledger-account.ts` — all confirmed 0-byte diff (G4/G5/G6 below).
+
+---
+
+## Gauntlet receipts
+
+Every check run with the direct binary under Node 20 (`v20.20.2`), output redirected to
+a file, exit code read from `$?` on the line immediately after the command and **outside
+any pipe**. Final full pass, all green:
+
+| Gate | Command                                                         | Result                            | How verified                                                 |
+| ---- | --------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------ |
+| G1   | `./node_modules/.bin/tsc --noEmit`                              | **exit 0**                        | `$?` immediately after, no pipe                              |
+| G2a  | `./node_modules/.bin/eslint .`                                  | **exit 0**, 39 warnings, 0 errors | `$?` after; output diffed against baseline (below)           |
+| G2b  | `./node_modules/.bin/prettier --check .`                        | **exit 0**                        | `$?` after; "All matched files use Prettier code style!"     |
+| G3   | `playwright test tests/signtx-unit.spec.ts --reporter=line`     | **exit 0**, **76 passed**         | `$?` after; 63 baseline + 12 S2 + 1 S3                       |
+| G4   | `git diff main -- package.json package-lock.json wasm/ assets/` | **0 bytes**                       | `wc -c` on the redirected diff                               |
+| G5   | `git diff main -- lib/wallet/account/ledger-account.ts`         | **0 bytes**                       | `wc -c` on the redirected diff                               |
+| G6   | shipped guards                                                  | **all 0 bytes**                   | see below                                                    |
+| G7   | `playwright test --reporter=line`                               | **76 passed, 1 failed**           | only `onboarding.spec.ts:7` — the known pre-existing failure |
+
+### G2 eslint — against a baseline captured before the first edit
+
+The baseline was captured on the unmodified tree before any edit. Note that a first
+attempt to size it via `wc -l < file` reported `0` for a file that is 6.3 KB on disk —
+the `rtk` shim fabricating output, exactly as warned. All subsequent comparisons use
+`diff(1)` on the redirected files and `ls -l` for size.
+
+Baseline vs final, complete:
+
+```
+105,107d104
+< /Users/leonardo/Repositories/s1/lib/wallet/account/hot-wallet-account.ts
+<   121:27  warning  'indexes' is defined but never used  @typescript-eslint/no-unused-vars
+<
+111c108
+< ✖ 40 problems (0 errors, 40 warnings)
+---
+> ✖ 39 problems (0 errors, 39 warnings)
+```
+
+The only change is a **removal**. No new warning anywhere, and none of the 39 remaining
+touches the five changed files.
+
+### G3 — 76 passing
+
+63 on the unmodified tree (the brief said 62; the tree has 63), + 12 S2 + 1 S3 = 76.
+
+### G6 — shipped guards byte-identical
+
+Every guard verified at 0 bytes of diff against `main`:
+
+| PR   | Guard                                                    | File                                        | Diff    |
+| ---- | -------------------------------------------------------- | ------------------------------------------- | ------- |
+| #306 | `assertSafeOutputSighash`, `ALLOW_UNSAFE_OUTPUT_SIGHASH` | `lib/wallet/sign-script.ts`                 | 0 bytes |
+| #306 | `toSignType` `hasOwnProperty` (`lib/kaspa.ts:68`)        | `lib/kaspa.ts`                              | 0 bytes |
+| #308 | `hasScriptOptions` + sign-only refusal                   | `lib/wallet/sign-script.ts`                 | 0 bytes |
+| #310 | `hasUnsignableFields`                                    | `lib/wallet/sign-script.ts`                 | 0 bytes |
+| #310 | `LEDGER_UNSIGNABLE_FIELDS_MESSAGE`                       | `components/.../LedgerSignAndBroadcast.tsx` | 0 bytes |
+| #312 | `getDerivationFields`                                    | `api/background/utils.ts`                   | 0 bytes |
+| #324 | `withOwned` thenable guard                               | `lib/wallet/wasm-lifecycle.ts`              | 0 bytes |
+
+Stronger statement: `git diff --name-only main...HEAD` filtered to exclude the five
+intended files returns **zero** files.
+
+### G7 — the one failure is the known one
+
+```
+1) [chromium] › tests/onboarding.spec.ts:7:1 › can reach password setup
+   Test timeout of 30000ms exceeded while setting up "context".
+1 failed, 76 passed
+```
+
+Pre-existing and deterministic on unmodified `main` in this environment, per the brief.
+Not touched, not "fixed".
+
+**Gauntlet passes used: 2.** Pass 1 green after S1+S2. Pass 2 restarted after the S3
+edits (one prettier re-format on `hot-wallet-account.ts`, then green).
+
+---
+
+## QA build
+
+```
+~/Desktop/kastle-qa-s1/          (38 MB, chrome-mv3, manifest v3)
+```
+
+Built with `npm run build` (exit 0). The manifest was marked **post-build only** and
+read back off disk to verify:
+
+```json
+{
+  "name": "Kastle (QA S1 2bcd44a)",
+  "version": "2.59.6",
+  "version_name": "2.59.6-s1-qa-2bcd44a"
+}
+```
+
+`npm run build` is a production build, so `isProduction` is true and **Sentry is
+enabled in this build** — which is what makes the check below possible at all. Load it
+in a Chrome profile that has no other Kastle build installed: two injectors racing on
+`window.kastle` will produce misleading results.
+
+---
+
+## How to prove nothing secret leaves
+
+The unit tests prove the redactor. This proves the **wiring** — that the redactor is
+actually on the path to the network.
+
+1. **Load the QA build.** `chrome://extensions` → Developer mode → Load unpacked →
+   `~/Desktop/kastle-qa-s1/`. Confirm the tile reads `Kastle (QA S1 2bcd44a)`.
+
+2. **Import a known throwaway phrase.** Use a phrase you can grep for and would never
+   fund, e.g.
+   `abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about`.
+
+3. **Open the popup in a full tab**, not the toolbar bubble — the bubble closes when
+   focus moves to devtools. Copy the extension ID from `chrome://extensions` and open
+   `chrome-extension://<ID>/popup.html`. Navigate to the backup screen so the phrase is
+   on screen.
+
+4. **Open devtools on that tab → Network → filter `sentry.io`.**
+
+5. **Trigger a deliberate error carrying the phrase.** In the Console:
+
+   ```js
+   const CANARY =
+     "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+   console.log("QA-CANARY", CANARY); // -> console breadcrumb
+   setTimeout(() => {
+     throw new Error("QA-CANARY " + CANARY);
+   }); // -> globalHandlers event
+   ```
+
+   The `console.log` exercises `beforeBreadcrumb`; the thrown error exercises
+   `beforeSend` and carries the breadcrumb with it. Those are the two vectors P0
+   identified.
+
+6. **Inspect the outbound envelope.** Click the request to `…ingest.us.sentry.io/…/envelope/`
+   → Payload / Request. Search it for `abandon`.
+
+**Pass:** zero occurrences of `abandon`. The message and the breadcrumb both read
+`QA-CANARY [REDACTED]`. **Fail:** any fragment of the phrase appears anywhere in the
+envelope.
+
+Worth repeating step 5 with a hex key and an `xprv`, which cover the other two patterns:
+
+```js
+console.log(
+  "QA-CANARY",
+  "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef",
+);
+setTimeout(() => {
+  throw new Error(
+    "QA-CANARY xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+  );
+});
+```
+
+And one negative control, to confirm Sentry still works and the scrubber is not simply
+eating everything:
+
+```js
+setTimeout(() => {
+  throw new Error("QA-CANARY benign network timeout");
+});
+```
+
+That envelope **should** contain `QA-CANARY benign network timeout` verbatim.
+
+---
+
+## Human gates — nothing done past the working tree
+
+No push, no PR, no tag, no merge, no release. Two local commits on
+`fix/sentry-secret-scrubbing` in `~/Repositories/s1`, and a QA build on the Desktop.
+
+## Left undone, deliberately
+
+- **S1.5 route-aware Sentry disabling** — skipped; rationale under S1 above.
+- **No end-to-end test through the real Sentry client.** The redactor has 12 unit
+  tests and the built bundle was grepped to confirm the hooks and `sendDefaultPii` are
+  present in the shipped bytes, but nothing in the gauntlet drives an actual
+  `Sentry.captureException` through a mock transport. That would need transport
+  scaffolding the brief explicitly warned off; the manual check above covers the same
+  ground with better fidelity, against the real build. If you would rather have it in
+  CI than in a runbook, say so and it is maybe 30 lines with a stub transport.
+- **Sentry token rotation** — out of scope per S4, untouched.

--- a/S1_SUMMARY.md
+++ b/S1_SUMMARY.md
@@ -465,6 +465,78 @@ That envelope **should** contain `QA-CANARY benign network timeout` verbatim.
 
 ---
 
+## Canary / negative-control verification (Part A + Part B)
+
+### Part A — automated, `tests/signtx-unit.spec.ts`
+
+`test.describe("sentry scrubbing wired into a real client")`, 4 tests. These
+drive a **real `@sentry/react` client** — same SDK, same event pipeline as
+production — differing only in a fake DSN (`https://abc123@o0.ingest.sentry.io/0`)
+and an in-memory `transport` that pushes envelopes into an array. **Nothing
+touches the network.** The hooks are `sentryScrubHooks` imported from
+`lib/sentry-scrub.ts`, not a copy: the redaction under test is the redaction
+that ships.
+
+| Test                                                                   | What it proves                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| canary: a phrase, a hex key and an xprv are all gone from the envelope | A 12-word phrase, a 64-hex key and an `xprv…` planted in a breadcrumb message, breadcrumb `data.arguments`, the error message, `extra.mnemonic`, `extra.nested.xprv` and `contexts.wallet.imported[0].raw` are all absent from the serialised envelope. Checked by recursing the **whole** envelope — headers, item headers, event body, arrays, any depth — not just top-level keys. Also asserts the fragments `abandon` and `xprv9s21` are absent, so a partial redaction cannot pass.                                                                                                                                                   |
+| negative control: a benign event arrives unchanged                     | An error message, a URL, a Kaspa address and a breadcrumb all arrive **verbatim**, and `[REDACTED]` appears nowhere. Without this, "nothing came through" and "scrubbing worked" are indistinguishable.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| each captureException produces exactly one envelope                    | One `captureException` → exactly one envelope, for both a secret-bearing and a benign error. A fail-closed scrubber that ate everything would show 0.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| lib/instrument.ts actually applies these hooks to Sentry.init          | Source-level drift guard: `lib/instrument.ts` contains `Sentry.init(` and `...sentryScrubHooks`. It is source-level because `instrument.ts` cannot be imported into the Playwright runner — it pulls `lib/utils.ts` and with it the app's asset graph, which the test transform cannot load (`SyntaxError: … '@/assets/images/network-logos/igra.svg' does not provide an export named 'default'`). That import failure is why `sentryScrubHooks` lives in `lib/sentry-scrub.ts` behind a **type-only** `@sentry/react` import (erased at compile time, so the module stays runtime-independent of the SDK) and `instrument.ts` spreads it. |
+
+One wrinkle worth recording: Sentry's scopes are module-global and survive
+`init`/`close`, so the canary's breadcrumbs initially rode along inside the
+control envelope and failed the negative control. `withIsolationScope` did not
+fix it; the helper now calls `clearBreadcrumbs()` on the global, isolation and
+current scopes before each capture.
+
+### Part B — manual, Settings → Experimental features (dev builds only)
+
+**There is no existing build-time debug gate in this repo.** The only debug-ish
+UI is the `/dev-mode` screen, and it is gated on the _runtime_ `settings.preview`
+checkbox — it ships in production. So the trigger uses `import.meta.env.DEV`,
+and the stripping is proven below rather than assumed (`wxt.config.ts` sets
+`minify: false`, so dead-code elimination, not minification, has to do the work).
+
+Steps for Leo:
+
+1. `nvm use 20 && npm run dev`, load `.output/chrome-mv3` in a profile with no
+   other Kastle build.
+2. Popup → **Settings** → **Experimental features**.
+3. Open the popup devtools console (right-click the popup → Inspect).
+4. Click **Trigger canary error** → the console prints
+   `[sentry-canary] { … }` — the full envelope JSON. Search it for `abandon`,
+   for the hex key, for `xprv9s21`: all absent, `[REDACTED]` in their place.
+5. Click **Trigger control error** → `[sentry-control] { … }` — the URL, the
+   status and the error text are all there, untouched, and `[REDACTED]` appears
+   nowhere.
+
+Why it prints instead of sending: the app's client is `enabled: isProduction`,
+so in a dev build `captureException` emits nothing at all and there would be
+nothing to look at. The trigger therefore builds its own client from the same
+`sentryScrubHooks` with a stub transport, and logs what would have gone on the
+wire. Nothing leaves the machine, and no event reaches the real Sentry project.
+
+### Production build is clean
+
+```
+npm run build            → exit 0
+grep -rl "Trigger canary error" .output/   → exit 1 (no matches)
+grep -rl "abandon abandon" .output/        → exit 1 (no matches)
+grep -rl "emitCanaryEnvelope" .output/     → exit 1 (no matches)
+```
+
+The button text, the test phrase and the handler are all absent from the
+production bundle. The `import.meta.env.DEV` gate strips the block.
+
+### Gauntlet, re-run after Part A + B
+
+- `tsc --noEmit` → 0
+- `eslint .` → 39 warnings, identical to the baseline
+- `prettier --check .` → 0
+- `playwright test tests/signtx-unit.spec.ts` → **80 passed** (76 existing + 4 new)
+- `git diff main...HEAD -- package.json package-lock.json wasm/ assets/ ledger-account.ts` → 0 bytes
+
 ## Human gates — nothing done past the working tree
 
 No push, no PR, no tag, no merge, no release. Two local commits on

--- a/S1_SUMMARY.md
+++ b/S1_SUMMARY.md
@@ -507,6 +507,21 @@ Steps for Leo:
 4. Click **Trigger canary error** → the console prints
    `[sentry-canary] { … }` — the full envelope JSON. Search it for `abandon`,
    for the hex key, for `xprv9s21`: all absent, `[REDACTED]` in their place.
+   Three of the plants are deliberately concatenation-shaped, since that is what
+   the review fix addressed:
+
+   | Field                                 | Planted                                                          | Expected                           |
+   | ------------------------------------- | ---------------------------------------------------------------- | ---------------------------------- |
+   | `exception…value`                     | `key=<hex>` (`=` is a non-word character, so this always worked) | `import failed for key=[REDACTED]` |
+   | breadcrumb `data.noSeparator`         | `privkey<hex>` — **no separator**                                | `privkey[REDACTED]`                |
+   | breadcrumb `data.noSeparatorExtended` | `seed<xprv>` — **no separator**                                  | `seed[REDACTED]`                   |
+
+   The prefix surviving matters as much as the redaction: `privkey[REDACTED]`
+   rather than a bare `[REDACTED]` shows the lookarounds cut exactly at the hex
+   run. Note the field is named `noSeparatorExtended`, not `noSeparatorXprv` —
+   the latter would be redacted by _key name_ and would prove nothing about the
+   value pattern.
+
 5. Click **Trigger control error** → `[sentry-control] { … }` — the URL, the
    status and the error text are all there, untouched, and `[REDACTED]` appears
    nowhere.
@@ -567,6 +582,12 @@ stating that ownership transfers.
 
 Three regression tests added: concatenated hex and xprv, a 128-char hex blob
 left intact, and a `kprv`-named key. 83 tests pass.
+
+Verified on device 2026-08-27 with the concatenated plants above: the envelope
+came back with `key=[REDACTED]`, `privkey[REDACTED]` and `seed[REDACTED]`, and
+zero occurrences of `b7e1516`, `xprv9s21` or `abandon`. On the pre-review build
+that middle line would have printed the key in full — the first device pass did
+not catch it because the original canary planted its secrets after a space.
 
 ## Human gates — nothing done past the working tree
 

--- a/components/screens/DevMode.tsx
+++ b/components/screens/DevMode.tsx
@@ -1,7 +1,85 @@
 import React from "react";
+import * as Sentry from "@sentry/react";
 import Header from "@/components/GeneralHeader";
 import { useSettings } from "@/hooks/useSettings";
+import { sentryScrubHooks } from "@/lib/sentry-scrub.ts";
 import { useNavigate } from "react-router-dom";
+
+/**
+ * Dev-only Sentry canary.
+ *
+ * ponytail: this drives its own Sentry client rather than the app's. The app's
+ * client is `enabled: isProduction`, so in a dev build `captureException` emits
+ * nothing at all — there would be nothing to look at. This one uses the real
+ * `sentryScrubHooks` (the same object lib/instrument.ts spreads into
+ * Sentry.init) with a fake DSN and a transport that prints the envelope instead
+ * of sending it, so nothing leaves the machine. Whatever you see printed is
+ * exactly what would have gone on the wire.
+ *
+ * `import.meta.env.DEV` is a build-time constant, so this whole block is absent
+ * from `npm run build` output. Note that the repo's only other debug UI,
+ * the "Experimental features" toggle below, is a *runtime* setting that does
+ * ship in production — there was no existing build-time gate to match.
+ */
+async function emitCanaryEnvelope(kind: "canary" | "control") {
+  // Well-known BIP-39 test vector plus a matching hex key and xprv — never a
+  // real wallet's secret.
+  const PHRASE =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+  const HEX =
+    "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef";
+  const XPRV =
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
+
+  Sentry.init({
+    ...sentryScrubHooks,
+    dsn: "https://abc123@o0.ingest.sentry.io/0",
+    enabled: true,
+    transport: () => ({
+      send: async (envelope: unknown) => {
+        console.log(
+          `[sentry-${kind}]`,
+          JSON.stringify(
+            envelope,
+            (_key, value) => (value instanceof Error ? String(value) : value),
+            2,
+          ),
+        );
+        return {};
+      },
+      flush: async () => true,
+    }),
+  });
+
+  Sentry.getGlobalScope().clearBreadcrumbs();
+  Sentry.getIsolationScope().clearBreadcrumbs();
+  Sentry.getCurrentScope().clearBreadcrumbs();
+
+  if (kind === "canary") {
+    Sentry.addBreadcrumb({
+      category: "console",
+      level: "log",
+      message: `user pasted ${PHRASE}`,
+      data: { arguments: [XPRV] },
+    });
+    Sentry.captureException(new Error(`import failed for key ${HEX}`), {
+      extra: { mnemonic: PHRASE, nested: { xprv: XPRV } },
+    });
+  } else {
+    Sentry.addBreadcrumb({
+      category: "console",
+      level: "log",
+      message: "refreshing balances",
+    });
+    Sentry.captureException(
+      new Error("Failed to fetch the Kaspa price: request timed out"),
+      { extra: { url: "https://api.kaspa.org/info/price", status: 504 } },
+    );
+  }
+
+  await Sentry.flush(2000);
+  await Sentry.close(2000);
+}
 
 export default function DevMode() {
   const navigate = useNavigate();
@@ -41,6 +119,34 @@ export default function DevMode() {
           />
         </div>
       </div>
+
+      {import.meta.env.DEV && (
+        <div className="flex flex-col gap-2 rounded-xl border border-gray-700 bg-[#1E343D] p-5">
+          <span className="font-semibold">
+            Sentry scrubbing check (dev only)
+          </span>
+          <span className="text-sm text-daintree-200">
+            Open the popup console. Each button prints the envelope that would
+            have been sent. Nothing is sent anywhere.
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-lg border border-icy-blue-400 px-3 py-2 text-sm"
+              onClick={() => emitCanaryEnvelope("canary")}
+            >
+              Trigger canary error
+            </button>
+            <button
+              type="button"
+              className="rounded-lg border border-gray-500 px-3 py-2 text-sm"
+              onClick={() => emitCanaryEnvelope("control")}
+            >
+              Trigger control error
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/screens/DevMode.tsx
+++ b/components/screens/DevMode.tsx
@@ -60,9 +60,19 @@ async function emitCanaryEnvelope(kind: "canary" | "control") {
       category: "console",
       level: "log",
       message: `user pasted ${PHRASE}`,
-      data: { arguments: [XPRV] },
+      data: {
+        arguments: [XPRV],
+        // No separator at all before the hex. This is the case `\b` anchoring
+        // used to miss: `\b` needs a non-word character on each side, and `y`
+        // is a word character.
+        noSeparator: `privkey${HEX}`,
+        // Same shape for the extended key.
+        noSeparatorExtended: `seed${XPRV}`,
+      },
     });
-    Sentry.captureException(new Error(`import failed for key ${HEX}`), {
+    // `key=` — a real log line's shape. `=` is a non-word character, so this
+    // one was always caught; it is here as the boundary control.
+    Sentry.captureException(new Error(`import failed for key=${HEX}`), {
       extra: { mnemonic: PHRASE, nested: { xprv: XPRV } },
     });
   } else {

--- a/lib/instrument.ts
+++ b/lib/instrument.ts
@@ -1,16 +1,11 @@
 import * as Sentry from "@sentry/react";
 import { isProduction } from "@/lib/utils.ts";
-import { scrubPayload } from "@/lib/sentry-scrub.ts";
+import { sentryScrubHooks } from "@/lib/sentry-scrub.ts";
 
 Sentry.init({
   dsn: "https://0712497db9071d6181d6006591b352d3@o431103.ingest.us.sentry.io/4508799037472768",
   enabled: isProduction,
-  // Never rely on the SDK's default here — the popup holds recovery phrases and
-  // private keys in memory.
-  sendDefaultPii: false,
-  // Console breadcrumbs and `globalHandlers` are on by default, so both the
-  // event and every breadcrumb are redacted before they leave the device.
-  // `scrubPayload` returns null on failure, which drops the payload.
-  beforeSend: (event) => scrubPayload(event),
-  beforeBreadcrumb: (breadcrumb) => scrubPayload(breadcrumb),
+  // sendDefaultPii, beforeSend and beforeBreadcrumb. Kept in sentry-scrub.ts so
+  // the canary tests can drive a real client with these exact hooks.
+  ...sentryScrubHooks,
 });

--- a/lib/instrument.ts
+++ b/lib/instrument.ts
@@ -1,7 +1,16 @@
 import * as Sentry from "@sentry/react";
 import { isProduction } from "@/lib/utils.ts";
+import { scrubPayload } from "@/lib/sentry-scrub.ts";
 
 Sentry.init({
   dsn: "https://0712497db9071d6181d6006591b352d3@o431103.ingest.us.sentry.io/4508799037472768",
   enabled: isProduction,
+  // Never rely on the SDK's default here — the popup holds recovery phrases and
+  // private keys in memory.
+  sendDefaultPii: false,
+  // Console breadcrumbs and `globalHandlers` are on by default, so both the
+  // event and every breadcrumb are redacted before they leave the device.
+  // `scrubPayload` returns null on failure, which drops the payload.
+  beforeSend: (event) => scrubPayload(event),
+  beforeBreadcrumb: (breadcrumb) => scrubPayload(breadcrumb),
 });

--- a/lib/sentry-scrub.ts
+++ b/lib/sentry-scrub.ts
@@ -26,15 +26,31 @@ const SECRET_KEY_PATTERN =
   /seed|mnemonic|privatekey|phrase|passphrase|password|secret|[xk]prv/i;
 
 /**
- * 32-byte hex — secp256k1 / Kaspa private keys, with or without `0x`.
+ * Separators are stripped before the key is tested, so `private_key`,
+ * `private-key` and `private key` all reduce to `privatekey`. Without this only
+ * the camelCase spelling matched, and `secret_key` passed by accident because
+ * `secret` happens to be an alternative of its own.
+ */
+const isSecretKey = (key: string) =>
+  SECRET_KEY_PATTERN.test(key.replace(/[^A-Za-z0-9]/g, ""));
+
+/**
+ * Any hex run long enough to contain a 32-byte key — secp256k1 / Kaspa private
+ * keys, with or without `0x`.
  *
  * Deliberately not `\b`-anchored: `\b` needs a non-word character on each side,
  * so `key${hex}` — plain string concatenation, which is exactly how a key ends
  * up in a log line — would not match. The lookarounds reject only adjacent *hex*
- * characters, so a longer hex blob is still left alone.
+ * characters, so the match still stops at the end of the run.
+ *
+ * `{64,}` rather than `{64}`: two concatenated keys are 128 characters and an
+ * exact-length pattern skips them entirely. Redacting the whole run costs
+ * serialised transactions and signatures in crash reports, which is the cheaper
+ * side of the trade — a 32-byte hash is indistinguishable from a 32-byte key, so
+ * every txid and block hash was already being redacted at exactly 64.
  */
 const HEX_KEY_PATTERN =
-  /(?<![0-9a-fA-F])(?:0x)?[0-9a-fA-F]{64}(?![0-9a-fA-F])/g;
+  /(?<![0-9a-fA-F])(?:0x)?[0-9a-fA-F]{64,}(?![0-9a-fA-F])/g;
 
 /**
  * BIP-32 extended private keys (`xprv…`) and their Kaspa variant (`kprv…`).
@@ -108,7 +124,7 @@ function scrub(value: unknown, seen: WeakSet<object>): unknown {
 
   const scrubbed: Record<string, unknown> = {};
   for (const [key, item] of entries) {
-    scrubbed[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : scrub(item, seen);
+    scrubbed[key] = isSecretKey(key) ? REDACTED : scrub(item, seen);
   }
   return scrubbed;
 }

--- a/lib/sentry-scrub.ts
+++ b/lib/sentry-scrub.ts
@@ -23,13 +23,28 @@ const BIP39_WORDS = new Set(english);
 
 /** Keys whose value is redacted whatever it looks like. */
 const SECRET_KEY_PATTERN =
-  /seed|mnemonic|privatekey|phrase|passphrase|password|secret|xprv/i;
+  /seed|mnemonic|privatekey|phrase|passphrase|password|secret|[xk]prv/i;
 
-/** 32-byte hex — secp256k1 / Kaspa private keys, with or without `0x`. */
-const HEX_KEY_PATTERN = /\b(?:0x)?[0-9a-fA-F]{64}\b/g;
+/**
+ * 32-byte hex — secp256k1 / Kaspa private keys, with or without `0x`.
+ *
+ * Deliberately not `\b`-anchored: `\b` needs a non-word character on each side,
+ * so `key${hex}` — plain string concatenation, which is exactly how a key ends
+ * up in a log line — would not match. The lookarounds reject only adjacent *hex*
+ * characters, so a longer hex blob is still left alone.
+ */
+const HEX_KEY_PATTERN =
+  /(?<![0-9a-fA-F])(?:0x)?[0-9a-fA-F]{64}(?![0-9a-fA-F])/g;
 
-/** BIP-32 extended private keys (`xprv…`) and their Kaspa variant (`kprv…`). */
-const EXTENDED_KEY_PATTERN = /\b[xk]prv[0-9A-Za-z]{20,}\b/g;
+/**
+ * BIP-32 extended private keys (`xprv…`) and their Kaspa variant (`kprv…`).
+ *
+ * Unanchored for the same reason. A leading lookbehind cannot help here: the key
+ * body is alphanumeric, so "not preceded by an alphanumeric" would reject
+ * `seed${xprv}` too. Over-matching is the safe direction — a word that happens
+ * to contain `xprv` followed by 20+ alphanumerics is not a real string.
+ */
+const EXTENDED_KEY_PATTERN = /[xk]prv[0-9A-Za-z]{20,}/g;
 
 const WORD_PATTERN = /[A-Za-z]+/g;
 

--- a/lib/sentry-scrub.ts
+++ b/lib/sentry-scrub.ts
@@ -1,0 +1,112 @@
+import { english } from "viem/accounts";
+
+/**
+ * Redaction for Sentry payloads.
+ *
+ * The popup holds raw recovery phrases and private keys in React state
+ * (`ShowWalletSecret`, the import flows). Sentry's default browser integrations
+ * capture console arguments as breadcrumbs and unhandled errors via
+ * `globalHandlers`, so any secret that reaches a log line or an error message
+ * would leave the device automatically. Everything sent to Sentry passes
+ * through here first.
+ *
+ * Pure and Sentry-independent so it can be unit tested directly.
+ */
+
+export const REDACTED = "[REDACTED]";
+
+/** A BIP-39 phrase is 12/15/18/21/24 words; 12 is the shortest that exists. */
+const MIN_MNEMONIC_WORDS = 12;
+
+const BIP39_WORDS = new Set(english);
+
+/** Keys whose value is redacted whatever it looks like. */
+const SECRET_KEY_PATTERN =
+  /seed|mnemonic|privatekey|phrase|passphrase|password|secret|xprv/i;
+
+/** 32-byte hex — secp256k1 / Kaspa private keys, with or without `0x`. */
+const HEX_KEY_PATTERN = /\b(?:0x)?[0-9a-fA-F]{64}\b/g;
+
+/** BIP-32 extended private keys (`xprv…`) and their Kaspa variant (`kprv…`). */
+const EXTENDED_KEY_PATTERN = /\b[xk]prv[0-9A-Za-z]{20,}\b/g;
+
+const WORD_PATTERN = /[A-Za-z]+/g;
+
+/**
+ * Replace every run of >= MIN_MNEMONIC_WORDS consecutive BIP-39 dictionary
+ * words. Separators between words are not inspected, so a phrase pasted with
+ * commas, newlines or numbering is still caught.
+ */
+export function redactMnemonics(text: string): string {
+  const words = [...text.matchAll(WORD_PATTERN)].map((match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+    inDictionary: BIP39_WORDS.has(match[0].toLowerCase()),
+  }));
+
+  const spans: Array<[number, number]> = [];
+  for (let i = 0; i < words.length; i++) {
+    if (!words[i].inDictionary) continue;
+    let last = i;
+    while (last + 1 < words.length && words[last + 1].inDictionary) last++;
+    if (last - i + 1 >= MIN_MNEMONIC_WORDS) {
+      spans.push([words[i].start, words[last].end]);
+    }
+    i = last;
+  }
+  if (spans.length === 0) return text;
+
+  let result = "";
+  let cursor = 0;
+  for (const [start, end] of spans) {
+    result += text.slice(cursor, start) + REDACTED;
+    cursor = end;
+  }
+  return result + text.slice(cursor);
+}
+
+export function redactString(text: string): string {
+  return redactMnemonics(
+    text
+      .replace(HEX_KEY_PATTERN, REDACTED)
+      .replace(EXTENDED_KEY_PATTERN, REDACTED),
+  );
+}
+
+function scrub(value: unknown, seen: WeakSet<object>): unknown {
+  if (typeof value === "string") return redactString(value);
+  if (typeof value !== "object" || value === null) return value;
+
+  // ponytail: cycles are dropped rather than tracked per-path; Sentry payloads
+  // are trees, so a repeat means a cycle in practice.
+  if (seen.has(value)) return REDACTED;
+  seen.add(value);
+
+  if (Array.isArray(value)) return value.map((item) => scrub(item, seen));
+
+  const entries = Object.entries(value);
+  // Errors, Dates and other exotic objects expose no enumerable own keys.
+  // Rebuilding them would throw the payload away, so hand them back untouched —
+  // Sentry serialises those itself before they reach the wire.
+  if (entries.length === 0) return value;
+
+  const scrubbed: Record<string, unknown> = {};
+  for (const [key, item] of entries) {
+    scrubbed[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : scrub(item, seen);
+  }
+  return scrubbed;
+}
+
+/**
+ * Recursively redact an arbitrary Sentry payload (event or breadcrumb).
+ *
+ * Fails closed: if redaction throws for any reason the caller must drop the
+ * payload rather than send it unscrubbed.
+ */
+export function scrubPayload<T>(payload: T): T | null {
+  try {
+    return scrub(payload, new WeakSet()) as T;
+  } catch {
+    return null;
+  }
+}

--- a/lib/sentry-scrub.ts
+++ b/lib/sentry-scrub.ts
@@ -1,3 +1,4 @@
+import type { Breadcrumb, BrowserOptions, ErrorEvent } from "@sentry/react";
 import { english } from "viem/accounts";
 
 /**
@@ -110,3 +111,26 @@ export function scrubPayload<T>(payload: T): T | null {
     return null;
   }
 }
+
+/**
+ * The privacy half of `Sentry.init`, kept here rather than inline in
+ * lib/instrument.ts so tests can drive a real Sentry client with the exact
+ * hooks production uses. instrument.ts spreads this object; importing it from
+ * there instead would drag the whole app asset graph into the test runner.
+ *
+ * The Sentry import above is type-only and erases at compile time, so this
+ * module stays runtime-independent of the SDK.
+ */
+export const sentryScrubHooks = {
+  // Never rely on the SDK's default here — the popup holds recovery phrases and
+  // private keys in memory.
+  sendDefaultPii: false,
+  // Console breadcrumbs and `globalHandlers` are on by default, so both the
+  // event and every breadcrumb are redacted before they leave the device.
+  // `scrubPayload` returns null on failure, which drops the payload.
+  beforeSend: (event: ErrorEvent) => scrubPayload(event),
+  beforeBreadcrumb: (breadcrumb: Breadcrumb) => scrubPayload(breadcrumb),
+} satisfies Pick<
+  BrowserOptions,
+  "sendDefaultPii" | "beforeSend" | "beforeBreadcrumb"
+>;

--- a/lib/wallet/account/hot-wallet-account.ts
+++ b/lib/wallet/account/hot-wallet-account.ts
@@ -56,7 +56,12 @@ export class LegacyHotWalletAccount implements IWallet {
   }
 
   signMessage(message: string): string {
-    return signMessage({ message, privateKey: this.getPrivateKeyString() });
+    // signMessage borrows the PrivateKey — it does not null the pointer — so
+    // getPrivateKey's ownership stays with us and withOwned frees it. Passing
+    // the object avoids materialising the key as a hex string.
+    return withOwned((own) =>
+      signMessage({ message, privateKey: own(this.getPrivateKey()) }),
+    );
   }
 
   protected getPrivateKey() {
@@ -69,23 +74,6 @@ export class LegacyHotWalletAccount implements IWallet {
         ),
       ).toPrivateKey(),
     );
-  }
-
-  protected getPrivateKeys(indexes: number[]) {
-    return withOwned((own) => {
-      const xprv = own(new XPrv(this.seed));
-
-      return indexes.map((index) =>
-        withOwned((ownIndex) => {
-          const derived = ownIndex(
-            xprv.derivePath(`m/44'/111111'/${this.accountIndex}'/0/${index}`),
-          );
-
-          return ownIndex(ownIndex(derived.toPrivateKey()).toKeypair())
-            .privateKey;
-        }),
-      );
-    });
   }
 }
 
@@ -116,11 +104,5 @@ export class HotWalletAccount extends LegacyHotWalletAccount {
         ),
       ).toPrivateKey(),
     );
-  }
-
-  override getPrivateKeys(indexes: number[]) {
-    return withOwned((own) => [
-      own(own(this.getPrivateKey()).toKeypair()).privateKey,
-    ]);
   }
 }

--- a/lib/wallet/account/hot-wallet-private-key.ts
+++ b/lib/wallet/account/hot-wallet-private-key.ts
@@ -34,6 +34,9 @@ export class HotWalletPrivateKey implements IWallet {
   }
 
   signMessage(message: string): string {
-    return signMessage({ message, privateKey: this.getPrivateKeyString() });
+    // signMessage borrows the PrivateKey — it does not null the pointer — and
+    // this one is owned by the instance, so pass the object straight through
+    // instead of materialising the key as a hex string.
+    return signMessage({ message, privateKey: this.privateKey });
   }
 }

--- a/lib/wallet/account/hot-wallet-private-key.ts
+++ b/lib/wallet/account/hot-wallet-private-key.ts
@@ -12,6 +12,9 @@ import { signTxWithScriptOptions } from "@/lib/wallet/sign-script.ts";
 export class HotWalletPrivateKey implements IWallet {
   keypair: Keypair;
 
+  // Takes ownership of the PrivateKey: it is retained for the lifetime of this
+  // instance and borrowed by every signing call, so the caller must not free it.
+  // Every call site constructs one inline for exactly this reason.
   constructor(private privateKey: PrivateKey) {
     this.keypair = privateKey.toKeypair();
   }

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -12,6 +12,7 @@ import init, {
   ScriptBuilder,
   SighashType,
   Transaction,
+  signMessage,
 } from "@/wasm/core/kaspa";
 import { deserializeTransaction } from "@/lib/kaspa-compat";
 import { REDACTED, scrubPayload } from "@/lib/sentry-scrub";
@@ -36,6 +37,7 @@ import {
   LegacyAccountFactory,
 } from "@/lib/wallet/account-factory";
 import { withOwned } from "@/lib/wallet/wasm-lifecycle";
+import { HotWalletPrivateKey } from "@/lib/wallet/account/hot-wallet-private-key";
 import type { SignType } from "@/lib/wallet/wallet-interface";
 
 // Throwaway key — unit tests only, never funded.
@@ -1562,4 +1564,35 @@ test.describe("sentry secret scrubbing", () => {
     expect(scrubbed.message).toBe(`key ${REDACTED}`);
     expect(scrubbed.self).toBe(REDACTED);
   });
+});
+
+// ---------------------------------------------------------------------------
+// S3 — HotWalletPrivateKey.signMessage now passes the PrivateKey object rather
+// than materialising a hex string. signMessage borrows (it does not null the
+// pointer), and the instance owns the key for its whole lifetime, so repeated
+// use must keep working and must agree with the old string path.
+// ---------------------------------------------------------------------------
+
+test("HotWalletPrivateKey.signMessage survives repeated use and matches the string path", () => {
+  const account = new HotWalletPrivateKey(new PrivateKey(TEST_KEY));
+
+  const viaString = signMessage({
+    message: "kastle-s3",
+    privateKey: TEST_KEY,
+    noAuxRand: true,
+  });
+
+  for (let i = 0; i < 20; i++) {
+    expect(account.signMessage("kastle-s3")).toMatch(/^[0-9a-f]{128}$/);
+  }
+
+  // Same key, same message, deterministic nonce => byte-identical signature,
+  // which is what proves the object hop is equivalent to the string hop.
+  expect(
+    signMessage({
+      message: "kastle-s3",
+      privateKey: account["privateKey"],
+      noAuxRand: true,
+    }),
+  ).toBe(viaString);
 });

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -14,6 +14,7 @@ import init, {
   Transaction,
 } from "@/wasm/core/kaspa";
 import { deserializeTransaction } from "@/lib/kaspa-compat";
+import { REDACTED, scrubPayload } from "@/lib/sentry-scrub";
 import {
   LedgerAccount,
   LegacyLedgerAccount,
@@ -1419,5 +1420,146 @@ test.describe("WASM secret lifecycle (W1)", () => {
     // withOwned() never frees on this path — the object leaks rather than
     // being corrupted out from under the still-suspended callback.
     expect(freed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S1 — Sentry secret scrubbing
+//
+// The popup holds raw recovery phrases and private keys in React state, and
+// Sentry's default browser integrations capture console arguments as
+// breadcrumbs plus unhandled errors via globalHandlers. `scrubPayload` is the
+// single control that stops any of that leaving the device, so it is tested
+// directly — it is pure and needs no Sentry client.
+// ---------------------------------------------------------------------------
+
+test.describe("sentry secret scrubbing", () => {
+  const PHRASE_12 =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+  const PHRASE_24 =
+    "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title";
+  const HEX_KEY =
+    "b7e2c1a3d4f50698abcdef0123456789b7e2c1a3d4f50698abcdef0123456789";
+  const XPRV =
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
+
+  test("redacts a 12-word BIP-39 phrase in a message", () => {
+    const scrubbed = scrubPayload({ message: `import failed: ${PHRASE_12}` });
+    expect(scrubbed?.message).not.toContain("abandon");
+    expect(scrubbed?.message).toBe(`import failed: ${REDACTED}`);
+  });
+
+  test("redacts a 24-word BIP-39 phrase in a message", () => {
+    const scrubbed = scrubPayload({ message: PHRASE_24 });
+    expect(scrubbed?.message).toBe(REDACTED);
+    expect(scrubbed?.message).not.toContain("sausage");
+  });
+
+  test("redacts a phrase pasted with punctuation and newlines", () => {
+    const noisy = PHRASE_12.split(" ").join(",\n");
+    const scrubbed = scrubPayload({ message: noisy });
+    expect(scrubbed?.message).not.toContain("abandon");
+  });
+
+  test("redacts a 64-char hex private key, bare and 0x-prefixed", () => {
+    expect(scrubPayload({ message: `key=${HEX_KEY}` })?.message).toBe(
+      `key=${REDACTED}`,
+    );
+    expect(scrubPayload({ message: `key=0x${HEX_KEY}` })?.message).toBe(
+      `key=${REDACTED}`,
+    );
+  });
+
+  test("redacts an xprv extended key", () => {
+    const scrubbed = scrubPayload({ message: `derive from ${XPRV}` });
+    expect(scrubbed?.message).toBe(`derive from ${REDACTED}`);
+  });
+
+  test("redacts secrets nested in extra, contexts and breadcrumb data", () => {
+    const scrubbed = scrubPayload({
+      message: "wallet error",
+      extra: { detail: { note: `phrase was ${PHRASE_12}` } },
+      contexts: { wallet: { imported: [{ key: HEX_KEY }] } },
+      breadcrumbs: [{ category: "console", data: { arguments: [XPRV] } }],
+    });
+
+    const serialised = JSON.stringify(scrubbed);
+    expect(serialised).not.toContain("abandon");
+    expect(serialised).not.toContain(HEX_KEY);
+    expect(serialised).not.toContain("xprv9s21");
+  });
+
+  test("redacts a breadcrumb payload the same way as an event", () => {
+    const scrubbed = scrubPayload({
+      category: "console",
+      level: "log",
+      message: `seed is ${PHRASE_12}`,
+      data: { arguments: [HEX_KEY] },
+    });
+    expect(scrubbed?.message).toBe(`seed is ${REDACTED}`);
+    expect(JSON.stringify(scrubbed?.data)).not.toContain(HEX_KEY);
+  });
+
+  test("redacts by field name even when the value looks harmless", () => {
+    const scrubbed = scrubPayload({
+      extra: {
+        mnemonic: "hello",
+        privateKey: 42,
+        passphrase: "",
+        password: null,
+        seedSource: { nested: "still gone" },
+        walletName: "my wallet",
+      },
+    });
+
+    const extra = scrubbed?.extra as Record<string, unknown>;
+    expect(extra.mnemonic).toBe(REDACTED);
+    expect(extra.privateKey).toBe(REDACTED);
+    expect(extra.passphrase).toBe(REDACTED);
+    expect(extra.password).toBe(REDACTED);
+    expect(extra.seedSource).toBe(REDACTED);
+    // Non-secret keys are untouched, otherwise Sentry stops being useful.
+    expect(extra.walletName).toBe("my wallet");
+  });
+
+  test("passes a benign event through unchanged", () => {
+    const benign = {
+      message: "Failed to fetch the Kaspa price: request timed out after 30s",
+      level: "error",
+      extra: {
+        url: "https://api.kaspa.org/info/price",
+        status: 504,
+        retries: 3,
+        address:
+          "kaspa:qzrq7v5jhsc5znvtfdg6vxg7dz5x8dqe4wrh3wfnsdwmpvxwqpqjqx0hfvhwd",
+      },
+      contexts: { app: { app_version: "2.59.6" } },
+    };
+    expect(scrubPayload(benign)).toEqual(benign);
+  });
+
+  test("leaves ordinary prose alone (no over-redaction)", () => {
+    // Long, entirely English, but not 12 dictionary words in a row.
+    const prose =
+      "Unable to sign the transaction because the connected hardware wallet " +
+      "returned an unexpected status code while deriving the account address.";
+    expect(scrubPayload({ message: prose })?.message).toBe(prose);
+  });
+
+  test("drops the payload instead of sending it when scrubbing throws", () => {
+    const exploding = {
+      get message(): string {
+        throw new Error("boom");
+      },
+    };
+    expect(scrubPayload(exploding)).toBeNull();
+  });
+
+  test("does not hang or leak on a cyclic payload", () => {
+    const cyclic: Record<string, unknown> = { message: `key ${HEX_KEY}` };
+    cyclic.self = cyclic;
+    const scrubbed = scrubPayload(cyclic) as Record<string, unknown>;
+    expect(scrubbed.message).toBe(`key ${REDACTED}`);
+    expect(scrubbed.self).toBe(REDACTED);
   });
 });

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -15,7 +15,9 @@ import init, {
   signMessage,
 } from "@/wasm/core/kaspa";
 import { deserializeTransaction } from "@/lib/kaspa-compat";
-import { REDACTED, scrubPayload } from "@/lib/sentry-scrub";
+import * as Sentry from "@sentry/react";
+import { REDACTED, scrubPayload, sentryScrubHooks } from "@/lib/sentry-scrub";
+
 import {
   LedgerAccount,
   LegacyLedgerAccount,
@@ -1595,4 +1597,173 @@ test("HotWalletPrivateKey.signMessage survives repeated use and matches the stri
       noAuxRand: true,
     }),
   ).toBe(viaString);
+});
+
+// ---------------------------------------------------------------------------
+// S1 Part A — the scrubber wired into a REAL Sentry client.
+//
+// The 12 tests above prove the redactor. These prove the *wiring*: that a real
+// Sentry.captureException, going through the real beforeSend/beforeBreadcrumb
+// from lib/instrument.ts, emits an envelope with the secrets gone and the
+// benign data intact. A stub transport captures the envelope in memory — no
+// network, no real DSN.
+//
+// The hooks are imported from lib/sentry-scrub.ts rather than re-declared, so
+// they cannot drift from production. lib/instrument.ts cannot be imported here
+// — it pulls lib/utils.ts and with it the app's asset graph, which the test
+// transform cannot load — so the last test asserts at source level that
+// instrument.ts really does spread them into Sentry.init.
+// ---------------------------------------------------------------------------
+
+test.describe("sentry scrubbing wired into a real client", () => {
+  const CANARY_PHRASE =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+  const CANARY_HEX =
+    "b7e2c1a3d4f50698abcdef0123456789b7e2c1a3d4f50698abcdef0123456789";
+  const CANARY_XPRV =
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi";
+
+  /** Every string anywhere in the structure, at any depth. */
+  function allStrings(value: unknown, found: string[] = []): string[] {
+    if (typeof value === "string") found.push(value);
+    else if (Array.isArray(value))
+      value.forEach((item) => allStrings(item, found));
+    else if (value && typeof value === "object")
+      Object.entries(value).forEach(([key, item]) => {
+        found.push(key);
+        allStrings(item, found);
+      });
+    return found;
+  }
+
+  /**
+   * Run `emit` against a real Sentry client whose only difference from
+   * production is a fake DSN and an in-memory transport. Returns every envelope
+   * the SDK tried to send.
+   */
+  async function captureWithStubTransport(emit: () => void) {
+    const envelopes: unknown[] = [];
+
+    Sentry.init({
+      ...sentryScrubHooks,
+      // Fake DSN: valid shape, points nowhere. The stub transport means nothing
+      // is ever dispatched regardless.
+      dsn: "https://abc123@o0.ingest.sentry.io/0",
+      // Production gates on isProduction, which is false under test; force it on
+      // so the client actually builds and sends an envelope.
+      enabled: true,
+      transport: () => ({
+        send: async (envelope: unknown) => {
+          envelopes.push(envelope);
+          return {};
+        },
+        flush: async () => true,
+      }),
+    });
+
+    // Scopes are module-global and survive init/close, so breadcrumbs from an
+    // earlier call would otherwise ride along in this envelope.
+    Sentry.getGlobalScope().clearBreadcrumbs();
+    Sentry.getIsolationScope().clearBreadcrumbs();
+    Sentry.getCurrentScope().clearBreadcrumbs();
+
+    emit();
+    await Sentry.flush(5000);
+    await Sentry.close(5000);
+
+    return envelopes;
+  }
+
+  test("canary: a phrase, a hex key and an xprv are all gone from the envelope", async () => {
+    const envelopes = await captureWithStubTransport(() => {
+      // Breadcrumb first: exercises beforeBreadcrumb, and the crumb rides along
+      // inside the event that follows.
+      Sentry.addBreadcrumb({
+        category: "console",
+        level: "log",
+        message: `user pasted ${CANARY_PHRASE}`,
+        data: { arguments: [CANARY_XPRV] },
+      });
+
+      const error = new Error(`import failed for key ${CANARY_HEX}`);
+      Sentry.captureException(error, {
+        extra: { mnemonic: CANARY_PHRASE, nested: { xprv: CANARY_XPRV } },
+        contexts: { wallet: { imported: [{ raw: CANARY_HEX }] } },
+      });
+    });
+
+    expect(envelopes).toHaveLength(1);
+
+    // Recurse the whole envelope — headers, item headers, event body,
+    // breadcrumbs, extra, contexts, arrays, any depth.
+    const strings = allStrings(envelopes[0]);
+    expect(strings.length).toBeGreaterThan(0);
+
+    const haystack = strings.join("\n");
+    expect(haystack).not.toContain(CANARY_PHRASE);
+    expect(haystack).not.toContain(CANARY_HEX);
+    expect(haystack).not.toContain(CANARY_XPRV);
+    // Fragments, not just the whole strings.
+    expect(haystack).not.toContain("abandon");
+    expect(haystack).not.toContain("xprv9s21");
+
+    // The event still went out, and it is still recognisably the same error.
+    expect(haystack).toContain("import failed for key");
+    expect(haystack).toContain(REDACTED);
+  });
+
+  test("negative control: a benign event arrives unchanged", async () => {
+    const benignUrl = "https://api.kaspa.org/info/price";
+    const benignAddress =
+      "kaspa:qzrq7v5jhsc5znvtfdg6vxg7dz5x8dqe4wrh3wfnsdwmpvxwqpqjqx0hfvhwd";
+    const benignMessage = "Failed to fetch the Kaspa price: request timed out";
+
+    const envelopes = await captureWithStubTransport(() => {
+      Sentry.addBreadcrumb({
+        category: "console",
+        level: "log",
+        message: "refreshing balances",
+      });
+      Sentry.captureException(new Error(benignMessage), {
+        extra: { url: benignUrl, status: 504, address: benignAddress },
+      });
+    });
+
+    expect(envelopes).toHaveLength(1);
+
+    const haystack = allStrings(envelopes[0]).join("\n");
+    // Without this the canary test is meaningless — "nothing came through" and
+    // "scrubbing worked" would look identical.
+    expect(haystack).toContain(benignMessage);
+    expect(haystack).toContain(benignUrl);
+    expect(haystack).toContain(benignAddress);
+    expect(haystack).toContain("refreshing balances");
+    expect(haystack).not.toContain(REDACTED);
+  });
+
+  test("each captureException produces exactly one envelope", async () => {
+    const canary = await captureWithStubTransport(() => {
+      Sentry.captureException(new Error(`key ${CANARY_HEX}`));
+    });
+    const control = await captureWithStubTransport(() => {
+      Sentry.captureException(new Error("plain failure"));
+    });
+
+    // Events are not being dropped wholesale — only secret-bearing fields are
+    // redacted. A fail-closed scrubber that ate everything would show 0 here.
+    expect(canary).toHaveLength(1);
+    expect(control).toHaveLength(1);
+  });
+
+  test("lib/instrument.ts actually applies these hooks to Sentry.init", () => {
+    // The tests above prove the hooks scrub. This proves production uses them.
+    // It is a source-level check because instrument.ts cannot be imported into
+    // the test runner (see the note at the top of this block).
+    const source = fs.readFileSync(
+      path.join(TESTS_DIR, "../lib/instrument.ts"),
+      "utf8",
+    );
+    expect(source).toContain("Sentry.init(");
+    expect(source).toContain("...sentryScrubHooks");
+  });
 });

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -1476,17 +1476,40 @@ test.describe("sentry secret scrubbing", () => {
     );
   });
 
-  test("leaves a longer hex blob alone", () => {
-    // A 128-char hex run is not a 32-byte key; only adjacent hex suppresses the
-    // match, so this stays intact rather than being half-redacted.
-    const blob = `${HEX_KEY}${HEX_KEY}`;
-    expect(scrubPayload({ message: blob })?.message).toBe(blob);
-  });
-
-  test("redacts a value under a kprv-named key", () => {
-    expect(scrubPayload({ kprv: "whatever shape this is" })?.kprv).toBe(
+  test("redacts a hex run longer than one key", () => {
+    // Two concatenated keys are 128 characters. An exact `{64}` pattern skips
+    // the run entirely, so the whole thing goes rather than nothing.
+    expect(scrubPayload({ message: `${HEX_KEY}${HEX_KEY}` })?.message).toBe(
       REDACTED,
     );
+    expect(scrubPayload({ message: `${HEX_KEY}a` })?.message).toBe(REDACTED);
+    // Still bounded: a run too short to hold a key is left alone.
+    const short = HEX_KEY.slice(0, 63);
+    expect(scrubPayload({ message: short })?.message).toBe(short);
+  });
+
+  test("redacts secret keys however they are spelled", () => {
+    for (const key of [
+      "kprv",
+      "privateKey",
+      "private_key",
+      "private-key",
+      "private key",
+      "x_prv",
+    ]) {
+      expect(scrubPayload({ [key]: "whatever shape this is" })?.[key]).toBe(
+        REDACTED,
+      );
+    }
+  });
+
+  test("redacts a secret-named key whatever its value type", () => {
+    const payload = scrubPayload({
+      private_key: { nested: ["deep", 1] },
+      mnemonic: ["a", "b"],
+    });
+    expect(payload?.private_key).toBe(REDACTED);
+    expect(payload?.mnemonic).toBe(REDACTED);
   });
 
   test("redacts a 64-char hex private key, bare and 0x-prefixed", () => {

--- a/tests/signtx-unit.spec.ts
+++ b/tests/signtx-unit.spec.ts
@@ -1465,6 +1465,30 @@ test.describe("sentry secret scrubbing", () => {
     expect(scrubbed?.message).not.toContain("abandon");
   });
 
+  test("redacts secrets concatenated straight onto adjacent text", () => {
+    // `\b` needs a non-word character on each side, so these were missed before:
+    // string concatenation is exactly how a key reaches a log line.
+    expect(scrubPayload({ message: `key${HEX_KEY}` })?.message).toBe(
+      `key${REDACTED}`,
+    );
+    expect(scrubPayload({ message: `seed${XPRV}` })?.message).toBe(
+      `seed${REDACTED}`,
+    );
+  });
+
+  test("leaves a longer hex blob alone", () => {
+    // A 128-char hex run is not a 32-byte key; only adjacent hex suppresses the
+    // match, so this stays intact rather than being half-redacted.
+    const blob = `${HEX_KEY}${HEX_KEY}`;
+    expect(scrubPayload({ message: blob })?.message).toBe(blob);
+  });
+
+  test("redacts a value under a kprv-named key", () => {
+    expect(scrubPayload({ kprv: "whatever shape this is" })?.kprv).toBe(
+      REDACTED,
+    );
+  });
+
   test("redacts a 64-char hex private key, bare and 0x-prefixed", () => {
     expect(scrubPayload({ message: `key=${HEX_KEY}` })?.message).toBe(
       `key=${REDACTED}`,


### PR DESCRIPTION
## Why

`Sentry.init` had no `beforeSend`, no `beforeBreadcrumb` and no explicit `sendDefaultPii`, while the popup holds raw recovery phrases and private keys in React state (`ShowWalletSecret`, the import flows).

Every other in-memory secret finding in this codebase needs an attacker with local code execution. This one is remote, passive and continuous: any error event or breadcrumb carrying seed material leaves the device automatically to a third-party service.

## What P0 found

The investigation that motivated this verified only that no scrubbing existed, not what Sentry actually captured. Establishing that first changed the shape of the fix:

- **Session Replay is OFF** — confirmed three ways. `replayIntegration` is absent from `@sentry/browser` 9.12.0's `getDefaultIntegrations()`, never added in config, and `grep -rl replayIntegration .output/` over the built extension returns nothing. No DOM capture of the displayed phrase was ever in play, so there is nothing to disable or mask.
- **The real vector is console breadcrumbs plus `globalHandlers`**, both on by default. `breadcrumbsIntegration` defaults to `console: true`, and its handler joins logged arguments with `safeJoin()` straight into `breadcrumb.message`.
- **`sendDefaultPii` has no default in 9.12.0** — `applyDefaultOptions()` never sets it, so it was `undefined`. In the browser SDK its only readers are `requestDataIntegration` and `trpcMiddleware`, neither in the default set, so it was inert rather than leaking. It is now set explicitly rather than inherited.
- **One `Sentry.init` site**, `lib/instrument.ts`, imported only by the popup. Background and content scripts do not initialise Sentry.
- **32 `console.*` call sites, none of which logs a secret today.** They are almost all `console.error(error)` in `catch` blocks. The exposure was the unscrubbed path, not an existing leak — one WASM error string or one added debug line was the whole distance.

## The fix

New `lib/sentry-scrub.ts` — pure and Sentry-independent, applied to every event and every breadcrumb. Redacts by two independent rules:

**By pattern:** ≥ 12 consecutive BIP-39 dictionary words (separators between words are not inspected, so a phrase pasted with commas or newlines is still caught), 64-char hex private keys with or without `0x`, and `xprv`/`kprv` extended keys.

**By field name:** `seed`, `mnemonic`, `privateKey`, `phrase`, `passphrase`, `password`, `secret`, `xprv` — the value goes whatever it is, including a whole nested object.

The walk is recursive over the entire payload (`message`, `exception.values`, `breadcrumbs[].data`, `extra`, `contexts`, `request`, arrays, any depth), with a `WeakSet` to break cycles. Objects with no enumerable own keys — `Error`, `Date`, class instances — are handed back untouched rather than rebuilt into `{}`, which would have destroyed the payload.

**It fails closed.** If redaction throws for any reason, `scrubPayload` returns `null`, and Sentry treats `null` from either hook as *drop*. An unscrubbed payload is never sent.

The BIP-39 wordlist comes from `viem`, already a direct dependency and already imported by `lib/utils.ts` — no dependency change, and no hand-rolled word heuristic that would over-redact ordinary prose.

Verified in the built bundle, not just the source: `.output/chrome-mv3/chunks/popup-*.js` contains `[REDACTED]`, `sendDefaultPii: false`, both hook wirings, and the wordlist.

### Deliberately not done

Disabling Sentry on secret-bearing routes. The SDK has no route predicate, so it would mean either a module-level flag every secret screen sets and clears on mount/unmount (leaks on an unmount that never fires, races with async errors surfacing after navigation) or threading router state into `beforeSend`. Both are more moving parts than the control they would back up, and the scrubber is route-independent — it covers screens not written yet.

## Bundled: W1b Tier-1 cleanup

Both verified independently rather than taken on trust.

**`getPrivateKeys()` ×2 deleted.** Zero callers, checked via the graph and a repo-wide grep including tests — two definition lines and four prose hits in W1 markdown, no call site. The `HotWalletAccount` override also ignored its `indexes` parameter entirely, always returning the single key for the account index, so any future caller would have been silently wrong. eslint corroborates: its pre-existing `'indexes' is defined but never used` warning goes with them.

**`signMessage` now takes the `PrivateKey` object** instead of materialising a hex string in JS memory purely to hand back to WASM. `ISignMessage.privateKey` is typed `PrivateKey | string`, and ownership was measured against the built wasm rather than inferred:

| Probe | Result |
|---|---|
| `signMessage` twice with the same `PrivateKey` | both succeed |
| `pk.toString()` afterwards | succeeds — pointer still live |
| `pk.free()` after all of the above | succeeds — this was the first real free |
| `pk.free()` a second time | throws `null pointer passed to rust` |
| object path vs string path, `noAuxRand: true` | byte-identical signature |

Same shape as `createInputSignature` in #324: **borrows, caller retains ownership and must free.** The double-free throwing is the load-bearing receipt — had `signMessage` consumed the pointer, the *first* `free()` would have thrown.

`HotWalletAccount` wraps it in `withOwned` (its `getPrivateKey()` hands ownership to the caller); `HotWalletPrivateKey` owns its key for the instance lifetime and needs no free.

## Tests

13 added, 76 passing total.

12 for the scrubber: 12-word and 24-word phrases, a phrase pasted with punctuation, hex keys bare and `0x`-prefixed, `xprv`, secrets nested in `extra` / `contexts` / a breadcrumb's `data`, a breadcrumb payload, field-name match against harmless values, the scrubber throwing → dropped, and a cyclic payload.

Two of them are the guard against making Sentry useless: a realistic benign error event carrying a Kaspa address and a version string must pass `toEqual`-unchanged, and a 24-word English sentence must survive intact.

1 for S3: `HotWalletPrivateKey.signMessage` had no coverage, so it now gets 20 repeated calls plus a byte-identical comparison against the string path. `HotWalletAccount.signMessage` was already covered by the W1 suite (20 calls × 6 legacy/new × index variants).

## Checks

- `tsc --noEmit` → 0
- `eslint .` → 0 errors, 39 warnings, diffed against a baseline captured before the first edit: the **only** change is the removal of the dead `indexes` warning (40 → 39). No new warning anywhere.
- `prettier --check .` → 0
- `playwright test tests/signtx-unit.spec.ts` → 76 passed
- Full suite → 76 passed, 1 failed: `onboarding.spec.ts:7`, which fails deterministically on unmodified `main` in this environment. Pre-existing, untouched.
- `package.json`, `package-lock.json`, `wasm/`, `assets/`, `ledger-account.ts` → **0 bytes** of diff
- Shipped guards from #306, #308, #310, #312, #324 → all 0 bytes. `git diff --name-only main...HEAD` filtered to exclude the five intended files returns zero files.

## Manual verification

The unit tests prove the redactor; the wiring is proven against a real build. `S1_SUMMARY.md` has the steps: load a known throwaway phrase, open the popup as a full tab, trigger a canary error and a canary `console.log` carrying the phrase, then inspect the outbound `…/envelope/` request in the Network tab. It includes a negative control that *should* come through verbatim, so "scrubbed" is distinguishable from "Sentry broken".

**Known gap:** nothing in CI drives an actual `Sentry.captureException` through a mock transport. The built bundle was grepped to confirm both hooks and `sendDefaultPii: false` are in the shipped bytes, but the end-to-end wiring proof is currently a runbook rather than a test. Happy to add it with a stub transport if reviewers would rather have it in CI.

Sentry token rotation is a separate open item and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Sensitive wallet data is automatically detected and redacted from error reports and diagnostic breadcrumbs.
  - Personal data collection for error reporting is disabled.
  - Reports are withheld if sensitive-data filtering cannot be completed safely.

- **Bug Fixes**
  - Improved message-signing reliability, including repeated signing operations.

- **Documentation**
  - Added engineering documentation and manual verification guidance for secret protection and reporting behavior.
  - Added development-only controls for verifying sensitive-data filtering and benign error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->