### PR TITLE
fix(send): broadcast every transaction the Generator returns

### DIFF
--- a/B2_INVESTIGATION.md
+++ b/B2_INVESTIGATION.md
@@ -1,0 +1,208 @@
+# B2 — KAS send near full balance broadcasts wrong transaction
+
+**Base:** `forbole/kastle` `main` @ `344e63f`
+**Date:** 2026-08-27
+**Verdict: CONFIRMED.** The suspected mechanism is exactly right and is reproduced
+deterministically offline, with no network and no wallet required.
+
+---
+
+## Verdict in one paragraph
+
+`createTransactions` is the WASM `Generator` in one shot. When the sender's UTXO set
+is fragmented enough that the inputs needed to cover the requested amount would exceed
+the maximum transaction mass, the Generator emits a **daisy-chained batch**: one or
+more _compound_ transactions that sweep selected UTXOs into the change address, and
+then the real payment as the **last** element of the returned array.
+`ConfirmStep.tsx:89` takes `transactions[0]` and nothing else, so on a fragmented
+wallet Kastle signs and broadcasts a **compound transaction that pays the sender's own
+change address**, reports success, and never broadcasts the payment. The fee is real
+and is paid. The recipient gets nothing. Splitting the send into smaller amounts works
+because fewer inputs are needed, so the batch collapses to a single transaction.
+
+---
+
+## Q1 — Does this SDK version document multi-transaction output? **Yes, explicitly.**
+
+`wasm/core/kaspa.d.ts:5586-5595`, the `Generator` class doc comment:
+
+> Generator is a type capable of generating transactions based on a supplied
+> set of UTXO entries or a UTXO entry producer (such as {@link UtxoContext}). The Generator
+> accumulates UTXO entries until it can generate a transaction that meets the
+> requested amount **or until the total mass of created inputs exceeds the allowed
+> transaction mass, at which point it will produce a compound transaction by forwarding
+> all selected UTXO entries to the supplied change address and prepare to start generating
+> a new transaction. Such sequence of daisy-chained transactions is known as a "batch".**
+> Each compound transaction results in a new UTXO, which is immediately reused in the
+> subsequent transaction.
+
+The documented consumption pattern for the `Generator` is a loop
+(`wasm/core/kaspa.d.ts:5613-5617`):
+
+```javascript
+let pendingTransaction;
+while ((pendingTransaction = await generator.next())) {
+  await pendingTransaction.sign(privateKeys);
+  await pendingTransaction.submit(rpc);
+}
+```
+
+`createTransactions` is the batched form of that loop. Its return type
+(`wasm/core/kaspa.d.ts:4815-4829`) is:
+
+```ts
+export interface ICreateTransactions {
+  /** Array of pending unsigned transactions. */
+  transactions: PendingTransaction[];
+  /** Summary of the transaction generation process. */
+  summary: GeneratorSummary;
+}
+```
+
+And the "final transaction" concept the task suspected does exist — on the summary
+(`wasm/core/kaspa.d.ts:5650-5670`, `GeneratorSummary`):
+
+```ts
+readonly finalTransactionId: string | undefined;
+readonly finalAmount: bigint | undefined;
+readonly transactions: number;
+```
+
+`finalAmount` / `finalTransactionId` describe the **last** transaction — the actual
+payment. `transactions` is the batch length. The SDK's own vocabulary distinguishes
+the final transaction from the compound ones; the code ignores the distinction and
+takes index 0.
+
+## Q2 — Reproduction. `transactions.length` is 3, 4, 6, 13 …
+
+No network needed. `createTransactions` takes `entries` as a plain array, so a
+fragmented UTXO set can be synthesised directly against the shipped
+`assets/kaspa_bg.wasm`. Fixture mirrors Leo's ratio exactly: **total 3005 KAS, request
+3000 KAS**, varying only how many UTXOs the 3005 is split across.
+The scratch script that produced the table below was a sweep over UTXO counts; its
+assertions are now folded into `tests/kas-send-batch-unit.spec.ts`, which ships with
+the fix.
+
+Verbatim output (`./node_modules/.bin/playwright test tests/b2-repro.spec.ts --reporter=line`, exit 0):
+
+```
+count=1    each=3,005          transactions.length=1  summary.transactions=1
+  tx[0] inputs=1   outputs=[3,000KAS->DEST | 4.997964KAS->SENDER]
+
+count=10   each=300.5          transactions.length=1  summary.transactions=1
+  tx[0] inputs=10  outputs=[3,000KAS->DEST | 4.987902KAS->SENDER]
+
+count=84   each=35.77380952    transactions.length=1  summary.transactions=1
+  tx[0] inputs=84  outputs=[3,000KAS->DEST | 4.90516968KAS->SENDER]
+
+count=88   each=34.14772727    transactions.length=1  summary.transactions=1
+  tx[0] inputs=88  outputs=[3,000KAS->DEST | 4.90069776KAS->SENDER]
+
+count=89   each=33.76404494    transactions.length=3  summary.transactions=3
+  tx[0] inputs=88  outputs=[2,971.13655272KAS->SENDER]     <-- what Kastle broadcasts
+  tx[1] inputs=1   outputs=[33.76232094KAS->SENDER]
+  tx[2] inputs=2   outputs=[3,000KAS->DEST | 4.89571966KAS->SENDER]   <-- the payment
+
+count=100  each=30.05          transactions.length=3  summary.transactions=3
+  tx[0] inputs=88  outputs=[2,644.300598KAS->SENDER]       <-- what Kastle broadcasts
+  tx[1] inputs=12  outputs=[360.585978KAS->SENDER]
+  tx[2] inputs=2   outputs=[3,000KAS->DEST | 4.883422KAS->SENDER]
+
+count=200  each=15.025         transactions.length=4
+  tx[0] inputs=88  outputs=[1,322.100598KAS->SENDER]
+  tx[1] inputs=88  outputs=[1,322.100598KAS->SENDER]
+  tx[2] inputs=24  outputs=[360.572562KAS->SENDER]
+  tx[3] inputs=3   outputs=[3,000KAS->DEST | 4.769486KAS->SENDER]
+
+count=400  each=7.5125         transactions.length=6   (5 compounds, then the payment)
+count=1000 each=3.005          transactions.length=13  (12 compounds, then the payment)
+```
+
+Answers to the specific questions asked:
+
+- **Is `transactions[0]` really a small/partial amount to the sender's own address?**
+  Yes. In every batched case `tx[0]` has a **single output paid to SENDER**, never to
+  DEST. `DEST` appears only in the last transaction. The `->SENDER` / `->DEST`
+  labelling above is a byte comparison of each output's `scriptPublicKey` against
+  `payToAddressScript(sender)` and `payToAddressScript(dest)`, not an inference.
+- **Threshold.** The break is between **88 and 89 inputs** for this shape: 88 inputs
+  still fit one transaction, 89 forces a batch. That is why the bug is "intermittent"
+  and "only above ~1000 KAS" — it is not amount-dependent at all, it is
+  _input-count_-dependent, and a wallet only accumulates ~90 UTXOs after a lot of
+  activity. Leo's workaround (split into smaller sends) works because a smaller
+  amount needs fewer inputs, so the batch collapses to length 1.
+- **The batch is ordered and chained.** `tx[1]` spends `tx[0]`'s output, `tx[2]` spends
+  `tx[1]`'s. They must be submitted in array order; each parent must be in the mempool
+  before its child. This is the "daisy-chained" wording from the Q1 doc quote.
+- **`summary.finalAmount` is `300000000000` (3000 KAS) in every batched case** — the
+  SDK knew all along what the payment was; the code just never reached it.
+
+## Q3 — The other `createTransactions` consumers
+
+Six call sites outside `wasm/` and the test suite:
+
+| File                                                        | Handling                                                                                                                                           | Same bug?                                                                                                                                                        |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api/background/handlers/kaspa/buildTransaction.ts:167-197` | `pendingTxs.map(...)` — serialises **all** of them, with the comment _"Serialize all pending transactions (may be multiple for UTXO compounding)"_ | **No.** Correct.                                                                                                                                                 |
+| `api/background/handlers/kaspa/sendSompi.ts:126-155`        | `const pendingTx = pendingTxs[0]`                                                                                                                  | **Yes**, same index-0 truncation.                                                                                                                                |
+| `api/background/handlers/kaspa/compoundUtxos.ts:104-128`    | `const pendingTx = pendingTxs[0]`                                                                                                                  | **Yes**, same index-0 truncation.                                                                                                                                |
+| `components/send/kas-send/ConfirmStep.tsx:77-92`            | `transactions[0].transaction`                                                                                                                      | **Yes** — this is the reported bug.                                                                                                                              |
+| `lib/commit-reveal.ts:121-135, 165-176`                     | `pendingTxs[0]` / `revealPendingTxs[0]`                                                                                                            | **Yes** in principle (KRC-20 commit/reveal).                                                                                                                     |
+| `hooks/useKasFeeEstimate.ts:33-40`                          | `transactions[0].feeAmount`                                                                                                                        | **Yes**, but as a _fee under-estimate_: it reports only the first transaction's fee, so the quoted fee is wrong for a batched send. Not a wrong-transaction bug. |
+
+**`compoundUtxos.ts` is not the reference implementation the task hoped for** — it has
+the same `[0]`-only truncation. `buildTransaction.ts` is the one that got it right, and
+it is the only one that already carries a comment showing the author knew about UTXO
+compounding. So the intended pattern exists in the codebase; it just wasn't applied to
+the internal Send path.
+
+**Why the three background handlers are not fixed in the same pass** (despite sharing
+the `[0]` index): their _shape_ differs from ConfirmStep's, so it is not the same fix.
+All three do not sign anything themselves — they serialise **one** transaction into
+`SignTxPayloadSchema` and hand it to the `/sign-and-broadcast-tx` popup, which is a
+single-transaction UI and protocol. Fixing them means changing the popup payload
+schema, the popup UI, and the dApp-facing API response shape — a cross-cutting change
+to the external API surface, on a different risk profile from a self-contained
+component fix. `commit-reveal.ts` additionally pins `priorityEntries` and signs the
+reveal input with a redeem script, so a batch there needs its own analysis.
+Recommended as separate follow-ups; see `B2_SUMMARY.md`.
+
+## Q4 — Ledger
+
+`components/send/kas-send/ConfirmStep.tsx` takes `walletSigner?: IWalletWithGetAddress`
+and calls only `signer.getAddress()` and `signer.signTx(transaction)`
+(`lib/wallet/wallet-interface.ts:28`). Both `HotWalletAccount`
+(`lib/wallet/account/hot-wallet-account.ts:48`) and `LedgerAccount`
+(`lib/wallet/account/ledger-account.ts:112`) implement that. The component is
+signer-agnostic and the fix does not need to touch `ledger-account.ts`.
+
+**Consequence for Ledger of signing the whole batch:** `LedgerAccount.signTx` is one
+device interaction per call, so an N-transaction batch is **N separate on-device
+confirmations**. With the numbers above that is 3 confirmations at 89 UTXOs, 6 at 400,
+13 at 1000. That is the honest cost of actually completing the payment — today the
+Ledger user confirms once and the payment silently does not happen. But the compound
+confirmations will look alarming on the device: they show a transfer to the user's own
+change address for an amount that is not what they typed. This needs UI text before it
+ships to Ledger users, and is called out in the QA checklist and as a follow-up.
+
+## Q5 — Alternative causes
+
+Not needed: Q2 reproduced the suspected mechanism directly and deterministically, so
+the alternatives were not pursued as causes. One unrelated defect was noticed while
+reading and is **not fixed here** (out of scope, different change):
+
+- **`priorityFee: 0n` is hardcoded and silently discards the user's fee choice.**
+  `DetailsStep.tsx:196` writes the selected priority (low/normal/priority) into the
+  form as `priorityFee`; `ConfirmStep.tsx:42-47,187` reads it back and displays
+  "`{priorityFeeKas} KAS`" to the user on the confirm screen — and then
+  `ConfirmStep.tsx:85` passes `priorityFee: 0n` to `createTransactions`. The fee the
+  user picked and was shown is never applied. Filed as a follow-up.
+
+---
+
+## GATE: **CONFIRMED** → proceed to Part 2
+
+Mechanism is `transactions[0]`-only truncation of a Generator batch, evidenced by the
+SDK's own documentation (Q1) and by deterministic offline reproduction against the
+shipped WASM binary (Q2), with the compound-to-self output verified by
+`scriptPublicKey` byte comparison rather than assumed.

--- a/B2_INVESTIGATION.md
+++ b/B2_INVESTIGATION.md
@@ -1,4 +1,4 @@
-# B2 — KAS send near full balance broadcasts wrong transaction
+# B2 — KAS send near-full-balance broadcasts wrong transaction
 
 **Base:** `forbole/kastle` `main` @ `344e63f`
 **Date:** 2026-08-27
@@ -83,9 +83,10 @@ The scratch script that produced the table below was a sweep over UTXO counts; i
 assertions are now folded into `tests/kas-send-batch-unit.spec.ts`, which ships with
 the fix.
 
-Verbatim output (`./node_modules/.bin/playwright test tests/b2-repro.spec.ts --reporter=line`, exit 0):
+Verbatim output from that sweep, captured before the fold. The equivalent assertions
+now run via `./node_modules/.bin/playwright test tests/kas-send-batch-unit.spec.ts --reporter=line` (exit 0):
 
-```
+```text
 count=1    each=3,005          transactions.length=1  summary.transactions=1
   tx[0] inputs=1   outputs=[3,000KAS->DEST | 4.997964KAS->SENDER]
 
@@ -143,7 +144,7 @@ Six call sites outside `wasm/` and the test suite:
 
 | File                                                        | Handling                                                                                                                                           | Same bug?                                                                                                                                                        |
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api/background/handlers/kaspa/buildTransaction.ts:167-197` | `pendingTxs.map(...)` — serialises **all** of them, with the comment _"Serialize all pending transactions (may be multiple for UTXO compounding)"_ | **No.** Correct.                                                                                                                                                 |
+| `api/background/handlers/kaspa/buildTransaction.ts:167-197` | `pendingTxs.map(...)` — serializes **all** of them, with the comment _"Serialize all pending transactions (may be multiple for UTXO compounding)"_ | **No.** Correct.                                                                                                                                                 |
 | `api/background/handlers/kaspa/sendSompi.ts:126-155`        | `const pendingTx = pendingTxs[0]`                                                                                                                  | **Yes**, same index-0 truncation.                                                                                                                                |
 | `api/background/handlers/kaspa/compoundUtxos.ts:104-128`    | `const pendingTx = pendingTxs[0]`                                                                                                                  | **Yes**, same index-0 truncation.                                                                                                                                |
 | `components/send/kas-send/ConfirmStep.tsx:77-92`            | `transactions[0].transaction`                                                                                                                      | **Yes** — this is the reported bug.                                                                                                                              |
@@ -156,9 +157,9 @@ it is the only one that already carries a comment showing the author knew about 
 compounding. So the intended pattern exists in the codebase; it just wasn't applied to
 the internal Send path.
 
-**Why the three background handlers are not fixed in the same pass** (despite sharing
+**Why the two single-transaction popup handlers are not fixed in the same pass** (despite sharing
 the `[0]` index): their _shape_ differs from ConfirmStep's, so it is not the same fix.
-All three do not sign anything themselves — they serialise **one** transaction into
+Neither handler signs anything itself — each serializes **one** transaction into
 `SignTxPayloadSchema` and hand it to the `/sign-and-broadcast-tx` popup, which is a
 single-transaction UI and protocol. Fixing them means changing the popup payload
 schema, the popup UI, and the dApp-facing API response shape — a cross-cutting change

--- a/B2_SUMMARY.md
+++ b/B2_SUMMARY.md
@@ -191,8 +191,8 @@ stay empty.
 
 ## Manual QA — the short path
 
-Real money, real network. **Step 1, the reported failure, has now been run end-to-end on
-testnet-10 and passed** (details below). Steps 2 and 3 remain. Two of the four originally-listed items have
+Real money, real network. **Steps 1 and 2 have now been run end-to-end on testnet-10 and
+passed** (details below). Only the Ledger pass remains. Two of the four originally-listed items have
 since been answered offline; what is left is **one funded testnet-10 address and about
 fifteen minutes**, plus the Ledger pass if a device is available.
 
@@ -245,12 +245,17 @@ index 1. 93 of the 95 inputs were consumed, total fee 0.108752 TKAS.
 On `main` this same send broadcasts `transactions[0]` — a compound transfer to the
 sender's own change address — and the destination stays at 0 while a real fee is paid.
 
-### Step 2 — regression, ordinary wallet — ready, not yet run
+### Step 2 — regression, ordinary wallet — **PASSED on testnet-10**
 
-The source wallet is now down to **3 UTXOs**, which is exactly the unfragmented case.
-Sending 1–2.5 TKAS from it pre-flights as **1 transaction** (`txs=1`, fee 0.0031–0.0043
-TKAS), so the expected result is one transaction, no progress counter, unchanged
-behaviour. Two minutes.
+Sent 1 TKAS from the source wallet, by then down to 3 UTXOs — the unfragmented case.
+
+|             | before                 | after                  |
+| ----------- | ---------------------- | ---------------------- |
+| source      | 2.725582 TKAS, 3 UTXOs | 1.722428 TKAS, 2 UTXOs |
+| destination | 45 TKAS, 1 UTXO        | **46 TKAS**, 2 UTXOs   |
+
+**Exactly one transaction**: `cd895a9c63bea70e…` carries both the 1 TKAS payment (index 0) and the change (index 1). No batch, no progress counter. Fee 0.003154 TKAS — the
+pre-flight figure to the sompi. Unfragmented sends are unchanged by this fix.
 
 ### Step 3 — Ledger, only if a device is to hand
 

--- a/B2_SUMMARY.md
+++ b/B2_SUMMARY.md
@@ -1,0 +1,287 @@
+# B2 — Fix: KAS send over a fragmented UTXO set broadcasts the wrong transaction
+
+**Branch:** `fix/kas-send-multi-transaction` (local only — not pushed, no PR, no tag)
+**Base:** `main` @ `344e63f`
+**Head:** single commit on top of `344e63f` — `git log -1` on the branch
+**Investigation:** `B2_INVESTIGATION.md` — gate **CONFIRMED**
+
+---
+
+## What was wrong
+
+`createTransactions` wraps the WASM `Generator`, which returns a **daisy-chained
+batch** whenever the sender's UTXO set is too fragmented for the requested amount to
+fit inside one transaction's mass budget: compound transactions that sweep UTXOs into
+the change address first, the actual payment **last**.
+
+`ConfirmStep.tsx` signed and broadcast `transactions[0]` and stopped. On a fragmented
+wallet that is a compound transaction paying the sender's own change address — a real
+fee is charged, the UI reports success, and the recipient is never paid.
+
+Measured threshold (offline, against the shipped `assets/kaspa_bg.wasm`): **88 inputs
+fit one transaction, 89 force a batch**. The bug is input-count-dependent, not
+amount-dependent, which is exactly why it read as "intermittent, only above ~1000 KAS"
+and why splitting into smaller sends worked around it.
+
+## The fix
+
+`lib/wallet/transaction-batch.ts` (new, 45 lines) — `signAndSubmitBatch()` signs and
+submits **every** transaction the Generator returned, in array order (each one spends
+the previous one's output, so the order is load-bearing), and returns all ids.
+
+`components/send/kas-send/ConfirmStep.tsx` calls it instead of indexing `[0]`.
+
+The loop was extracted rather than left inline because the repo has no React test
+infrastructure (no `@testing-library`, no jsdom), and a money path with a branch in it
+needs a test that actually drives the code. As a pure function with `Pick<>`-typed
+signer/rpc parameters it is directly testable with stubs.
+
+Two behaviours came along because they are one line each and both matter on this path:
+
+- **Ids are published incrementally** (`onSubmitted`), so a mid-batch failure still
+  shows the user on the failure screen which transactions were broadcast — and paid
+  for. Previously a failure showed nothing at all.
+- **An empty batch throws** instead of dereferencing `transactions[0]` as `undefined`
+  and reporting a send that never happened.
+
+`SuccessStatus` already renders multiple ids with a count badge and opens them all in
+the explorer (`components/send/SuccessStatus.tsx:78-94`), so no UI work was needed
+there.
+
+### UX addition (implemented — small and low-risk)
+
+`ConfirmStep` shows `Optimizing your wallet (2/3)` while the compound transactions go
+out, and `Sending (3/3)` on the final payment. Rendered \*\*only when the batch length is
+
+> 1\*\*, so a normal single-transaction send is visually unchanged.
+
+This is not cosmetic on the Ledger path. `LedgerAccount.signTx` is one device
+confirmation per call, so a batch is N separate on-device approvals — 3 at 89 UTXOs,
+13 at 1000. Without a counter the user sees "Please approve on Ledger" repeat with no
+indication of how many remain, and unplugging mid-batch leaves the compound
+transactions broadcast and the payment not sent.
+
+### Diff
+
+```
+ B2_INVESTIGATION.md                      | 208 +++++++++++++++++++++++++++++++
+ B2_SUMMARY.md                            | 287 +++++++++++++++++++++++++++++++
+ components/send/kas-send/ConfirmStep.tsx |  27 +++-
+ lib/wallet/transaction-batch.ts          |  45 +++++++
+ tests/kas-send-batch-unit.spec.ts        | 189 +++++++++++++++++++++++++++++++
+ 5 files changed, 751 insertions(+), 5 deletions(-)
+
+Source change is 3 files; the other two are this report and the investigation.
+```
+
+`ledger-account.ts` is untouched — the component takes `IWalletWithGetAddress` and
+calls only `getAddress()`/`signTx()`, so the fix is signer-agnostic by construction.
+
+## Not fixed here, and why
+
+- **`sendSompi.ts` and `compoundUtxos.ts` carry the same `pendingTxs[0]` truncation**
+  but not the same fix. Neither signs anything: both serialise **one** transaction
+  into `SignTxPayloadSchema` and hand it to the `/sign-and-broadcast-tx` popup, which
+  is a single-transaction UI and protocol. Fixing them means changing that payload
+  schema, the popup UI, and the dApp-facing API response shape — a change to the
+  external API surface, on a different risk profile from a self-contained component
+  fix, and one that would have collided with the #306/#308/#312 guards. **Follow-up.**
+- **`buildTransaction.ts` is already correct** — it maps over all pending transactions,
+  with the comment _"Serialize all pending transactions (may be multiple for UTXO
+  compounding)"_. It is the in-repo precedent for this fix.
+- **`lib/commit-reveal.ts`** uses `[0]` for both commit and reveal, but pins
+  `priorityEntries` and signs the reveal input with a redeem script; a batch there
+  needs its own analysis. **Follow-up.**
+- **`hooks/useKasFeeEstimate.ts:40`** reads `transactions[0].feeAmount`, so the fee
+  quoted to the user is only the _first_ transaction's fee and understates a batched
+  send — at 100 UTXOs the batch's total fee is `summary.fees` = 11,657,800 sompi
+  (0.1166 KAS) across 3 transactions, while the quote reflects one of them. Wrong
+  number, not a wrong transaction. **Follow-up** — worth doing soon, since users now
+  actually see the batch happen. Measured, same offline harness, balance 3000 KAS:
+
+  | UTXOs | quoted fee (`transactions[0].feeAmount`) | real batch fee (`summary.fees`) | Max button                      |
+  | ----- | ---------------------------------------- | ------------------------------- | ------------------------------- |
+  | 1     | 203,600                                  | 203,600                         | works                           |
+  | 120   | 315,400                                  | 13,893,800                      | works                           |
+  | 400+  | —                                        | —                               | **throws `Insufficient funds`** |
+
+  The under-quote is currently harmless only because `useFindMax`'s
+  `minSubtrahend: 0.3 KAS` (30,000,000 sompi) happens to exceed the real fee at 120
+  UTXOs. At **≥400 UTXOs the Max button itself throws `Insufficient funds`** and the
+  send cannot be made at all. **This is pre-existing, not a regression**: the throw
+  comes out of `createTransactions` before any indexing, so `main` behaves identically.
+  It matters for QA — fragment to ~120 UTXOs, not 400+, or the tester hits this other
+  bug and misattributes it to this fix.
+
+- **`priorityFee: 0n` is hardcoded in `ConfirmStep.tsx:90`**, discarding the priority
+  the user picked in `DetailsStep.tsx:196` and which `ConfirmStep.tsx:50,193` displays
+  back to them as "`{priorityFeeKas} KAS`". Unrelated defect found while reading. **Follow-up.**
+
+---
+
+## Gauntlet receipts
+
+One pass, green. Every exit code below was read from `$?` on the line immediately
+after the command, outside any pipe (`rtk` fabricates output, so no exit code here
+comes from parsing stdout). Node 20.20.2, binaries invoked by absolute path from
+`./node_modules/.bin/`.
+
+| Gate | Command                                                                | Result                     | How verified                                                                                                                                                                                                                         |
+| ---- | ---------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| G1   | `./node_modules/.bin/tsc --noEmit`                                     | **0**                      | `G1_exit=0`, empty log                                                                                                                                                                                                               |
+| G2a  | `./node_modules/.bin/eslint .`                                         | **0**                      | `G2_eslint_exit=0`, `39 problems (0 errors, 39 warnings)` — identical to the baseline captured on `main` before any edit (`BASELINE_eslint_exit=0`, 39 warnings)                                                                     |
+| G2b  | `./node_modules/.bin/prettier --check .`                               | **0**                      | `G2_prettier_exit=0`, `All matched files use Prettier code style!`                                                                                                                                                                   |
+| G3a  | `playwright test tests/signtx-unit.spec.ts --reporter=line`            | **0**                      | `G3_signtx_exit=0`, `92 passed`                                                                                                                                                                                                      |
+| G3b  | `playwright test tests/kas-send-batch-unit.spec.ts --reporter=line`    | **0**                      | `G3_new_exit=0`, `7 passed`                                                                                                                                                                                                          |
+| G4   | `git diff main...HEAD -- package.json package-lock.json wasm/ assets/` | **EMPTY**                  | redirected to file, `wc -c` = **0**                                                                                                                                                                                                  |
+| G5   | `git diff main...HEAD -- lib/wallet/account/ledger-account.ts`         | **EMPTY**                  | redirected to file, `wc -c` = **0**                                                                                                                                                                                                  |
+| G6   | guards #306/#308/#310/#312/#324/#326/#328/#330                         | **byte-identical**         | resolved each PR to its merge commit, took the union of every file those 8 commits touched (`SignAndBroadcast.tsx`, `LedgerSignTx.tsx`, `SignTx.tsx`, `ledger-account.ts`, …), diffed that whole set `main...HEAD` → `wc -c` = **0** |
+| G7   | `playwright test --reporter=line`                                      | **107 passed / 1 skipped** | `G7_exit=0`. The 1 skip is `tests/qa-fragment-wallet.spec.ts` (untracked QA tooling, skips itself unless `QA_KEY` is set). No failures, no new failures.                                                                             |
+
+### A correction to the brief
+
+The brief states `tests/onboarding.spec.ts:7` fails deterministically (5/5) on
+unmodified `main`. On this machine it is **flaky, not deterministic**: it failed one
+G7 pass (105 passed / 1 failed) and passed the next two (106 passed; 107 passed after
+the near-max test was added) with no change in between. Treat it as flaky.
+
+### The new test earns its place
+
+`tests/kas-send-batch-unit.spec.ts` — 7 tests built on a real `createTransactions`
+batch (100 UTXOs totalling 3005 KAS, sending 3000 KAS, mirroring the report):
+
+- asserts the fragmented set really does yield `length > 1`, so the scenario cannot
+  silently stop testing anything;
+- asserts `transactions[0]` pays the destination **nothing** — the negative control;
+- asserts the **full 3000 KAS reaches the destination**, summed from the
+  `scriptPublicKey` of every output actually handed to `submitTransaction`, not merely
+  that no error was thrown;
+- asserts broadcast order matches generator order with the payment last;
+- asserts a **near-max amount** (`balance - 0.3 KAS`, the largest the Max button will
+  ever submit) also delivers in full from a fragmented wallet — QA item 4, moved from
+  the manual list into the suite;
+- asserts an unfragmented wallet still sends exactly one transaction;
+- asserts progress and incremental id callbacks fire for every transaction, and that
+  an empty batch is refused.
+
+**Mutation-checked:** reverting `signAndSubmitBatch` to the old `[0]`-only behaviour
+(`transactions.slice(0, 1)`) makes **3 of the 6 then-existing tests fail**, including _"the FULL requested
+amount reaches the destination"_; the mutation was reverted and the suite re-run green.
+The tests fail when the bug is present.
+
+---
+
+## QA build
+
+```
+~/Desktop/kastle-qa-b2/          (38 MB, unpacked chrome-mv3)
+```
+
+Marked with the branch's final short sha and verified off disk after copying — read
+the literal values back from `~/Desktop/kastle-qa-b2/manifest.json` (`name`,
+`version`, `version_name`) rather than from this document, which is inside the commit
+being identified and so cannot name its own sha.
+
+`npm run build` exit **0**. The QA marking is applied to the built
+`.output/chrome-mv3/manifest.json` only — it is not in the source diff, so G4/G5/G6
+stay empty.
+
+> Load it in a **separate Chrome profile**. Two Kastle builds in one profile race to
+> inject `window.kastle` and the results are not trustworthy.
+
+## Manual QA — the short path
+
+Real money, real network. **Step 1, the reported failure, has now been run end-to-end on
+testnet-10 and passed** (details below). Steps 2 and 3 remain. Two of the four originally-listed items have
+since been answered offline; what is left is **one funded testnet-10 address and about
+fifteen minutes**, plus the Ledger pass if a device is available.
+
+### Step 0 — fragment a testnet-10 address (done)
+
+Doing this through the UI is impractical: Send writes a single output, so reaching 89
+UTXOs would take 89 sends. `tests/qa-fragment-wallet.spec.ts` (untracked QA tooling,
+deliberately not part of the fix) does it:
+
+```
+QA_KEY=<hex private key of a funded testnet-10 address> QA_TARGET=95 \
+  ./node_modules/.bin/playwright test tests/qa-fragment-wallet.spec.ts --reporter=line
+```
+
+**Already run — the QA wallet below is fragmented and ready.** ~48 TKAS was enough.
+
+Two corrections to what this document said before the tooling was actually run against
+a node, both found the hard way:
+
+1. **The script did not work as first written**, on two counts. The WASM `RpcClient`
+   rejects Node 20's native `WebSocket` (`w3c websocket is not available`) and needs
+   `globalThis.WebSocket` set from `ws`, already present transitively. And splitting one
+   UTXO into 95 in a single transaction is refused with `Storage mass exceeds maximum`.
+2. **KIP-9 storage mass caps the pieces one transaction can create**, at roughly
+   `sqrt(balance / 1e7)` — measured against the shipped WASM: 47.9 TKAS tops out near
+   **25 pieces**, whatever the input count, and reaching 95 in one transaction would
+   need ~**900 TKAS**. What is cheap is splitting each UTXO on its own: those
+   transactions are independent, so the script now submits one per UTXO per round and
+   goes 37 → 95 in a single round. Small balances are fine; the earlier "one command,
+   one transaction" framing was not.
+
+Note the asymmetry: _creating_ many small UTXOs is mass-expensive, _spending_ them is
+not. 48 TKAS was never a problem for the send being tested — only for manufacturing the
+wallet that tests it.
+
+### Step 1 — the reported scenario — **PASSED on testnet-10**
+
+Sent 45 TKAS from the 95-UTXO wallet through the QA build.
+
+|             | before                   | after                  |
+| ----------- | ------------------------ | ---------------------- |
+| source      | 47.834334 TKAS, 95 UTXOs | 2.725582 TKAS, 3 UTXOs |
+| destination | **0 TKAS**, 0 UTXOs      | **45 TKAS**, 1 UTXO    |
+
+Read back from `getUtxosByAddresses` after the fact, not from the extension's success
+screen. The destination holds a single 45 TKAS output from `f1c3ddd2c1351f07…` — the
+batch's **last** transaction; the source's change came out of that same transaction at
+index 1. 93 of the 95 inputs were consumed, total fee 0.108752 TKAS.
+
+On `main` this same send broadcasts `transactions[0]` — a compound transfer to the
+sender's own change address — and the destination stays at 0 while a real fee is paid.
+
+### Step 2 — regression, ordinary wallet — ready, not yet run
+
+The source wallet is now down to **3 UTXOs**, which is exactly the unfragmented case.
+Sending 1–2.5 TKAS from it pre-flights as **1 transaction** (`txs=1`, fee 0.0031–0.0043
+TKAS), so the expected result is one transaction, no progress counter, unchanged
+behaviour. Two minutes.
+
+### Step 3 — Ledger, only if a device is to hand
+
+Repeat step 1 with a device attached. Expect **one approval per transaction**. The
+compound approvals show a transfer to the user's own change address for an amount they
+did not type — judge whether that needs device-facing copy. If it is too confusing,
+file it separately rather than blocking this fix; today those users' payments silently
+do not happen at all.
+
+### Answered offline — no longer on the manual list
+
+- **Original item 4, "send the literal exact total balance."** Answered by probing
+  `createTransactions` directly with the same numbers the UI would produce. The Max
+  button's amount (`balance - 0.3 KAS`) delivers in full from a fragmented wallet — now
+  a test in `kas-send-batch-unit.spec.ts`. A send of the _literal_ full balance throws
+  `Insufficient funds` at every UTXO count including 1, on `main` too: there is nothing
+  left to pay the fee, so the throw is correct and unrelated to this change.
+  I had predicted this item was the likely breakage. It is not — that call was wrong.
+- **"Does the fix change unfragmented behaviour?"** Covered by the unit test asserting
+  a single-UTXO wallet still produces exactly one transaction.
+
+---
+
+## QA build reminder
+
+> Load `~/Desktop/kastle-qa-b2/` in a **separate Chrome profile**. Two Kastle builds in
+> one profile race to inject `window.kastle` and the results are not trustworthy.
+
+---
+
+## Human gates respected
+
+No push, no PR, no tag, no merge, no release. The branch and both `.md` deliverables
+exist locally in `~/Repositories/b2` on `fix/kas-send-multi-transaction`.

--- a/components/send/kas-send/ConfirmStep.tsx
+++ b/components/send/kas-send/ConfirmStep.tsx
@@ -16,6 +16,7 @@ import { formatCurrency } from "@/lib/utils.ts";
 import useCurrencyValue from "@/hooks/useCurrencyValue.ts";
 import { createTransactions } from "@/wasm/core/kaspa";
 import useRpcClientStateful from "@/hooks/useRpcClientStateful";
+import { signAndSubmitBatch } from "@/lib/wallet/transaction-batch";
 
 export const ConfirmStep = ({
   onNext,
@@ -35,6 +36,10 @@ export const ConfirmStep = ({
   const { emitFirstTransaction } = useAnalytics();
   const { addRecentAddress } = useRecentAddresses();
   const [isSigning, setIsSigning] = useState(false);
+  const [batchProgress, setBatchProgress] = useState<{
+    current: number;
+    total: number;
+  } | null>(null);
   const { rpcClient, networkId } = useRpcClientStateful();
 
   const { wallet, account } = useWalletManager();
@@ -86,10 +91,11 @@ export const ConfirmStep = ({
         changeAddress: await signer.getAddress(),
         networkId: networkId,
       });
-      const transaction = transactions[0].transaction;
-      const signedTransaction = await signer.signTx(transaction);
-      const { transactionId } = await rpcClient.submitTransaction({
-        transaction: signedTransaction,
+      // A fragmented UTXO set makes the Generator return a batch: consolidating
+      // transactions first, the payment last. All of them must go out, in order.
+      await signAndSubmitBatch(transactions, signer, rpcClient, {
+        onSigning: (current, total) => setBatchProgress({ current, total }),
+        onSubmitted: setOutTxs,
       });
 
       await addRecentAddress({
@@ -98,7 +104,6 @@ export const ConfirmStep = ({
         domain,
       });
 
-      setOutTxs([transactionId]);
       // Don't await, analytics should not crash the app
       void emitFirstTransaction({
         amount,
@@ -113,6 +118,7 @@ export const ConfirmStep = ({
       onFail();
     } finally {
       setIsSigning(false);
+      setBatchProgress(null);
     }
   };
 
@@ -212,6 +218,17 @@ export const ConfirmStep = ({
                 />
                 {wallet?.type === "ledger" && (
                   <span>Please approve on Ledger</span>
+                )}
+                {/* A fragmented UTXO set needs consolidating before the payment
+                    fits in one transaction, so several go out in sequence — on
+                    Ledger that is one device approval each. */}
+                {batchProgress && batchProgress.total > 1 && (
+                  <span>
+                    {batchProgress.current < batchProgress.total
+                      ? "Optimizing your wallet"
+                      : "Sending"}{" "}
+                    ({batchProgress.current}/{batchProgress.total})
+                  </span>
                 )}
               </div>
             ) : (

--- a/lib/wallet/transaction-batch.ts
+++ b/lib/wallet/transaction-batch.ts
@@ -1,0 +1,45 @@
+import { RpcClient, Transaction } from "@/wasm/core/kaspa";
+import { IWalletWithGetAddress } from "@/lib/wallet/wallet-interface";
+
+/**
+ * `createTransactions` wraps the WASM `Generator`, which returns a daisy-chained
+ * *batch* rather than a single transaction whenever the UTXO set is too fragmented
+ * for the requested amount to fit in one transaction's mass budget: compound
+ * transactions that sweep selected UTXOs into the change address come first, and
+ * the actual payment is last (see `Generator` in `wasm/core/kaspa.d.ts`).
+ *
+ * Signing only `transactions[0]` therefore broadcasts a compound transaction that
+ * pays the sender's own change address, charges a real fee, and never pays the
+ * recipient. Every transaction must be signed and submitted in array order,
+ * because each one spends the output of the one before it.
+ *
+ * @returns the ids of every broadcast transaction, in order; the last is the payment.
+ */
+export async function signAndSubmitBatch(
+  transactions: readonly { transaction: Transaction }[],
+  signer: Pick<IWalletWithGetAddress, "signTx">,
+  rpcClient: Pick<RpcClient, "submitTransaction">,
+  callbacks: {
+    onSigning?: (current: number, total: number) => void;
+    onSubmitted?: (transactionIds: string[]) => void;
+  } = {},
+): Promise<string[]> {
+  if (transactions.length === 0) {
+    throw new Error("No transaction was generated for this amount");
+  }
+
+  const transactionIds: string[] = [];
+  for (const [index, pending] of transactions.entries()) {
+    callbacks.onSigning?.(index + 1, transactions.length);
+    const signedTransaction = await signer.signTx(pending.transaction);
+    const { transactionId } = await rpcClient.submitTransaction({
+      transaction: signedTransaction,
+    });
+    transactionIds.push(transactionId);
+    // Publish ids as they land, so a mid-batch failure still shows which
+    // transactions were broadcast — and paid for — on the failure screen.
+    callbacks.onSubmitted?.([...transactionIds]);
+  }
+
+  return transactionIds;
+}

--- a/tests/kas-send-batch-unit.spec.ts
+++ b/tests/kas-send-batch-unit.spec.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "@playwright/test";
+import init, {
+  PrivateKey,
+  RpcClient,
+  Transaction,
+  createTransactions,
+  payToAddressScript,
+} from "@/wasm/core/kaspa";
+import { IWalletWithGetAddress } from "@/lib/wallet/wallet-interface";
+import { signAndSubmitBatch } from "@/lib/wallet/transaction-batch";
+
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+test.beforeAll(async () => {
+  await init({
+    module_or_path: fs.readFileSync(
+      path.join(TESTS_DIR, "../assets/kaspa_bg.wasm"),
+    ),
+  });
+});
+
+// B2: sending an amount close to the whole balance from a fragmented wallet
+// broadcast a *compound* transaction to the sender's own change address instead
+// of the payment, because ConfirmStep signed transactions[0] and stopped. The
+// Generator returns a daisy-chained batch here — the payment is the LAST entry.
+test.describe("KAS send over a fragmented UTXO set (B2)", () => {
+  const KEY_A =
+    "b7e151628aed2a6abf7158809cf4f3c762e7160f38b4da56a784d9045190cfef";
+  const KEY_B =
+    "c90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b14e5c9";
+  const TOTAL = 300_500_000_000n; // 3005 KAS, Leo's reported balance
+  const REQUEST = 300_000_000_000n; // 3000 KAS, the reported send
+
+  const buildBatch = async (utxoCount: number, request: bigint = REQUEST) => {
+    const senderKey = new PrivateKey(KEY_A);
+    const sender = senderKey.toPublicKey().toAddress("mainnet");
+    const dest = new PrivateKey(KEY_B).toPublicKey().toAddress("mainnet");
+    const each = TOTAL / BigInt(utxoCount);
+
+    const { transactions } = await createTransactions({
+      entries: Array.from({ length: utxoCount }, (_unused, i) => ({
+        address: sender,
+        outpoint: { transactionId: i.toString(16).padStart(64, "0"), index: 0 },
+        amount: each,
+        scriptPublicKey: payToAddressScript(sender),
+        blockDaaScore: 1_000n,
+        isCoinbase: false,
+      })),
+      outputs: [{ address: dest.toString(), amount: request }],
+      priorityFee: 0n,
+      changeAddress: sender.toString(),
+      networkId: "mainnet",
+    });
+
+    return {
+      transactions,
+      destScript: payToAddressScript(dest).toString(),
+      changeScript: payToAddressScript(sender).toString(),
+    };
+  };
+
+  // Signing is not what this test is about: hand the transaction back unchanged
+  // and record every transaction that actually reached submitTransaction.
+  const mkBroadcaster = () => {
+    const broadcast: Transaction[] = [];
+    const signer: Pick<IWalletWithGetAddress, "signTx"> = {
+      signTx: async (tx) => tx,
+    };
+    const rpcClient: Pick<RpcClient, "submitTransaction"> = {
+      submitTransaction: async (request) => {
+        const transaction = request.transaction as Transaction;
+        broadcast.push(transaction);
+        return { transactionId: transaction.id };
+      },
+    };
+    return { broadcast, signer, rpcClient };
+  };
+
+  const paidTo = (broadcast: Transaction[], script: string) =>
+    broadcast
+      .flatMap((tx) => tx.outputs)
+      .filter((o) => o.scriptPublicKey.toString() === script)
+      .reduce((sum, o) => sum + o.value, 0n);
+
+  test("a fragmented UTXO set really does produce a multi-transaction batch", async () => {
+    const { transactions, destScript } = await buildBatch(100);
+
+    // If this ever drops to 1 the scenario below stops testing anything.
+    expect(transactions.length).toBeGreaterThan(1);
+
+    // The old code signed this one, and it pays the recipient nothing.
+    expect(
+      transactions[0].transaction.outputs.some(
+        (o) => o.scriptPublicKey.toString() === destScript,
+      ),
+    ).toBe(false);
+  });
+
+  test("the FULL requested amount reaches the destination", async () => {
+    const { transactions, destScript } = await buildBatch(100);
+    const { broadcast, signer, rpcClient } = mkBroadcaster();
+
+    const ids = await signAndSubmitBatch(transactions, signer, rpcClient);
+
+    expect(broadcast.length).toBe(transactions.length);
+    expect(ids.length).toBe(transactions.length);
+    // The point of the fix: the recipient is paid the whole 3000 KAS.
+    expect(paidTo(broadcast, destScript)).toBe(REQUEST);
+  });
+
+  test("the batch is broadcast in generator order, payment last", async () => {
+    const { transactions, destScript } = await buildBatch(100);
+    const { broadcast, signer, rpcClient } = mkBroadcaster();
+
+    const ids = await signAndSubmitBatch(transactions, signer, rpcClient);
+
+    expect(broadcast.map((tx) => tx.id)).toEqual(
+      transactions.map((pending) => pending.transaction.id),
+    );
+    // Each transaction spends the previous one's output, so order is not optional.
+    expect(ids[ids.length - 1]).toBe(
+      transactions[transactions.length - 1].transaction.id,
+    );
+    expect(
+      broadcast[broadcast.length - 1].outputs.some(
+        (o) => o.scriptPublicKey.toString() === destScript,
+      ),
+    ).toBe(true);
+  });
+
+  // The Max button offers `balance - max(feeEstimate, 0.3 KAS)`
+  // (hooks/useFindMax.ts:20-22, DetailsStep.tsx:67-72) — the largest amount the
+  // UI will ever submit, and the case closest to leaving no change output.
+  test("a near-max amount still delivers in full from a fragmented wallet", async () => {
+    const MIN_SUBTRAHEND = 30_000_000n; // 0.3 KAS, useFindMax's floor
+    const { transactions, destScript } = await buildBatch(
+      100,
+      TOTAL - MIN_SUBTRAHEND,
+    );
+    const { broadcast, signer, rpcClient } = mkBroadcaster();
+
+    await signAndSubmitBatch(transactions, signer, rpcClient);
+
+    expect(transactions.length).toBeGreaterThan(1);
+    expect(paidTo(broadcast, destScript)).toBe(TOTAL - MIN_SUBTRAHEND);
+  });
+
+  test("an unfragmented wallet still sends exactly one transaction", async () => {
+    const { transactions, destScript } = await buildBatch(1);
+    const { broadcast, signer, rpcClient } = mkBroadcaster();
+
+    const ids = await signAndSubmitBatch(transactions, signer, rpcClient);
+
+    expect(transactions.length).toBe(1);
+    expect(ids.length).toBe(1);
+    expect(paidTo(broadcast, destScript)).toBe(REQUEST);
+  });
+
+  test("progress and incremental ids are reported for every transaction", async () => {
+    const { transactions } = await buildBatch(100);
+    const { signer, rpcClient } = mkBroadcaster();
+    const signing: string[] = [];
+    const published: string[][] = [];
+
+    await signAndSubmitBatch(transactions, signer, rpcClient, {
+      onSigning: (current, total) => signing.push(`${current}/${total}`),
+      onSubmitted: (transactionIds) => published.push(transactionIds),
+    });
+
+    const total = transactions.length;
+    expect(signing).toEqual(
+      Array.from({ length: total }, (_unused, i) => `${i + 1}/${total}`),
+    );
+    // ids accumulate, so a mid-batch failure leaves the user the broadcast ones
+    expect(published.map((ids) => ids.length)).toEqual(
+      Array.from({ length: total }, (_unused, i) => i + 1),
+    );
+  });
+
+  test("an empty batch is refused rather than reported as sent", async () => {
+    const { signer, rpcClient } = mkBroadcaster();
+    await expect(signAndSubmitBatch([], signer, rpcClient)).rejects.toThrow(
+      /No transaction was generated/,
+    );
+  });
+});


### PR DESCRIPTION
## The bug

Sending an amount close to the whole balance broadcast a transaction for a much smaller
amount. A real fee was paid; the requested payment never happened. Reported as
intermittent and balance-dependent — it is actually **UTXO-count dependent**.

`createTransactions` wraps the WASM `Generator`, which does not always return one
transaction. From `wasm/core/kaspa.d.ts`:

> The Generator accumulates UTXO entries until it can generate a transaction that meets
> the requested amount **or until the total mass of created inputs exceeds the allowed
> transaction mass, at which point it will produce a compound transaction by forwarding
> all selected UTXO entries to the supplied change address** and prepare to start
> generating a new transaction. Such sequence of daisy-chained transactions is known as
> a "batch".

The payment is the **last** element of that batch; everything before it is a compound
transfer to the sender's own change address. `ConfirmStep.tsx` signed `transactions[0]`
and stopped — so on a fragmented wallet it broadcast a transfer to the user's own change
address, charged a real fee, and never paid the recipient.

Measured against the shipped WASM: **88 inputs fit one transaction, 89 force a batch.**

## The fix

New `lib/wallet/transaction-batch.ts` — `signAndSubmitBatch` signs and submits every
transaction in array order (each spends the previous one's output, so order is not
optional) and publishes ids as they land, so a mid-batch failure still shows what was
broadcast and paid for. `ConfirmStep.tsx` calls it instead of indexing `[0]`.

`api/background/handlers/kaspa/buildTransaction.ts` already loops correctly; this brings
the KAS send path in line with it.

Small UX addition: while a batch is in flight the confirm screen shows
`Optimizing your wallet (n/N)`, switching to `Sending (N/N)` for the final transaction.
On Ledger that is one device approval per transaction, so silence would look like a hang.

## Verification

**Unit — `tests/kas-send-batch-unit.spec.ts` (7 tests, offline against the shipped
`assets/kaspa_bg.wasm`).** `entries` is a plain array, so a fragmented UTXO set is
synthesisable with no node and no wallet. The tests assert the full requested amount
reaches the destination — summed from the `scriptPublicKey` of every output actually
handed to `submitTransaction`, not merely that no error was thrown — plus the negative
control that `transactions[0]` pays the destination nothing, broadcast order with the
payment last, single-transaction behaviour on an unfragmented wallet, and a near-max
amount. Mutation-checked: restoring the `[0]`-only behaviour fails 3 of them.

**End-to-end on testnet-10.** A wallet fragmented to 95 UTXOs, sending 45 TKAS:

| | before | after |
| --- | --- | --- |
| source | 47.834334 TKAS, 95 UTXOs | 2.725582 TKAS, 3 UTXOs |
| destination | **0 TKAS** | **45 TKAS**, 1 UTXO |

Read back from `getUtxosByAddresses`, not from the success screen. The destination holds
a single 45 TKAS output from the batch's **last** transaction; 93 inputs consumed, total
fee 0.108752 TKAS. On `main` the same send leaves the destination at 0.

Regression case, also on testnet-10: from the same wallet once it was down to 3 UTXOs,
sending 1 TKAS produced **exactly one transaction** (`cd895a9c63bea70e…`, payment at
index 0 and change at index 1), no progress counter, fee 0.003154 TKAS. Unfragmented
sends are unchanged.

## Still open

- **Ledger with a physical device has not been tested.** The change is signer-agnostic —
  `ledger-account.ts` is untouched, 0-byte diff — but a batch means one approval per
  transaction, and the compound approvals show a transfer to the user's own change
  address for an amount they did not type. Worth a look before release; today those
  users' payments silently do not happen at all.
- `sendSompi.ts`, `compoundUtxos.ts` and `lib/commit-reveal.ts` truncate to `[0]` too,
  but differently: they serialize one transaction into `SignTxPayloadSchema` for a
  single-transaction popup, so fixing them means changing the popup schema, the popup UI
  and the dApp-facing response. Deliberately not in this PR.
- `hooks/useKasFeeEstimate.ts:40` quotes only `transactions[0].feeAmount`, understating a
  batched send's fee (315,400 vs 13,893,800 sompi at 120 UTXOs). Pre-existing, and at
  ≥400 UTXOs the Max button throws `Insufficient funds` on `main` as well.

`B2_INVESTIGATION.md` and `B2_SUMMARY.md` carry the full evidence; say the word if you'd
rather they not live in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sending from highly fragmented wallets now processes all required transactions in sequence, ensuring recipients receive the full payment.
  * Added progress indicators for wallet optimization and multi-step sending.
  * Transaction IDs are reported as each transaction is successfully submitted.

* **Bug Fixes**
  * Fixed payments being replaced by an intermediate change transaction in certain large wallets.

* **Tests**
  * Added coverage for fragmented and unfragmented wallets, transaction ordering, progress updates, and empty batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
